### PR TITLE
fix: await cookies in API routes

### DIFF
--- a/app/api/admin/logout/route.js
+++ b/app/api/admin/logout/route.js
@@ -3,7 +3,8 @@ import { NextResponse } from "next/server";
 
 export async function POST() {
   // Delete cookie
-  cookies().delete("admin_token");
+  const cookieStore = await cookies();
+  cookieStore.delete("admin_token");
 
   return NextResponse.json({ message: "Logged out successfully" });
 }

--- a/app/api/cart/[productId]/route.js
+++ b/app/api/cart/[productId]/route.js
@@ -9,7 +9,7 @@ export async function PUT(req, { params }) {
   await dbConnect();
 
   try {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     const token = cookieStore.get("auth_token")?.value;
 
     if (!token) {
@@ -64,7 +64,7 @@ export async function DELETE(req, { params }) {
   await dbConnect();
 
   try {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     const token = cookieStore.get("auth_token")?.value;
 
     if (!token) {

--- a/app/api/cart/apply-promo/route.js
+++ b/app/api/cart/apply-promo/route.js
@@ -9,9 +9,9 @@ import { cookies } from "next/headers";
 export async function POST(req) {
 	await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(

--- a/app/api/cart/clear/route.js
+++ b/app/api/cart/clear/route.js
@@ -8,9 +8,9 @@ import { cookies } from "next/headers";
 export async function DELETE() {
 	await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(

--- a/app/api/cart/remove-promo/route.js
+++ b/app/api/cart/remove-promo/route.js
@@ -9,9 +9,9 @@ import { cookies } from "next/headers";
 export async function DELETE(req) {
 	await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(

--- a/app/api/cart/route.js
+++ b/app/api/cart/route.js
@@ -7,11 +7,11 @@ import { verifyToken } from "@/lib/auth.js";
 import { cookies } from "next/headers";
 
 export async function GET() {
-	await dbConnect();
+        await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(
@@ -40,11 +40,11 @@ export async function GET() {
 }
 
 export async function POST(req) {
-	await dbConnect();
+        await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(

--- a/app/api/products/reviews/route.js
+++ b/app/api/products/reviews/route.js
@@ -7,9 +7,9 @@ import { cookies } from "next/headers";
 export async function POST(req, { params }) {
 	await dbConnect();
 
-	try {
-		const cookieStore = cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
 		if (!token) {
 			return Response.json(

--- a/app/api/seller/company/createCompany/route.js
+++ b/app/api/seller/company/createCompany/route.js
@@ -9,8 +9,8 @@ export async function POST(req) {
   try {
     await dbConnect();
 
-    const cookieStore = cookies();
-    const token = await cookieStore.get("seller-auth-token")?.value;
+    const cookieStore = await cookies();
+    const token = cookieStore.get("seller-auth-token")?.value;
 
 
     if (!token) {

--- a/app/api/seller/company/getCompany/route.js
+++ b/app/api/seller/company/getCompany/route.js
@@ -11,8 +11,8 @@ export async function GET() {
     await dbConnect();
 
 
-    const cookieStore = cookies();
-    const token = await cookieStore.get("seller-auth-token")?.value;
+    const cookieStore = await cookies();
+    const token = cookieStore.get("seller-auth-token")?.value;
 
     if (!token) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/seller/company/updateCompany/route.js
+++ b/app/api/seller/company/updateCompany/route.js
@@ -9,8 +9,8 @@ export async function PUT(req) {
   try {
     await dbConnect();
 
-    const cookieStore = cookies();
-    const token = await cookieStore.get("seller-auth-token")?.value;
+    const cookieStore = await cookies();
+    const token = cookieStore.get("seller-auth-token")?.value;
 
     if (!token) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/seller/logout/route.js
+++ b/app/api/seller/logout/route.js
@@ -3,7 +3,8 @@ import { NextResponse } from "next/server";
 
 export async function POST() {
   // Delete cookie
-  cookies().delete("seller-auth-token");
+  const cookieStore = await cookies();
+  cookieStore.delete("seller-auth-token");
 
   return NextResponse.json({ message: "Logged out successfully" });
 }


### PR DESCRIPTION
## Summary
- fix Next.js dynamic API usage by awaiting `cookies()` before reading values or deleting tokens across API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot serialize key 'parse' in parser: Function values are not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c510d56bac832ea8d1a84bbb43aad0