### PR TITLE
Hide empty sections on home page

### DIFF
--- a/components/BuyerPanel/home/FeaturedSection.jsx
+++ b/components/BuyerPanel/home/FeaturedSection.jsx
@@ -9,84 +9,113 @@ import { ProductCardVarient } from "@/components/BuyerPanel/home/ProductCardVari
 import BannerImg from "@/public/images/home/Banner.png";
 
 export default function FeaturedSection({
-	topSellingProducts = [],
-	bestSellingProduct = null,
-	featuredProducts = [],
+        topSellingProducts = [],
+        bestSellingProduct = null,
+        featuredProducts = [],
 }) {
-	return (
-		<section className="py-8 md:py-16 bg-gray-50">
-			<div className="px-10">
-				{/* Top Selling Products */}
-				<motion.div
-					initial={{ opacity: 0, y: 20 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					className="mb-12 md:mb-16"
-				>
-					<h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
-						Top Selling Products
-					</h2>
-					<ProductCarousel products={topSellingProducts} showDots={true} />
-				</motion.div>
-			</div>
+        const hasTopSelling = topSellingProducts?.length > 0;
+        const hasBestSelling = !!bestSellingProduct;
+        const hasFeatured = featuredProducts?.length > 0;
+        const hasAnyContent = hasTopSelling || hasBestSelling || hasFeatured;
 
-			<div className="px-10">
-				{/* Best Selling Product */}
-				{bestSellingProduct && <FeaturedProduct product={bestSellingProduct} />}
-			</div>
+        if (!hasAnyContent) {
+                return null;
+        }
 
-			<Image
-				src={BannerImg}
-				alt="Banner"
-				className="w-full h-auto mb-12 md:mb-16 object-cover"
-			/>
+        return (
+                <section className="py-8 md:py-16 bg-gray-50">
+                        {hasTopSelling && (
+                                <div className="px-10">
+                                        {/* Top Selling Products */}
+                                        <motion.div
+                                                initial={{ opacity: 0, y: 20 }}
+                                                whileInView={{ opacity: 1, y: 0 }}
+                                                viewport={{ once: true }}
+                                                className="mb-12 md:mb-16"
+                                        >
+                                                <h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
+                                                        Top Selling Products
+                                                </h2>
+                                                <ProductCarousel
+                                                        products={topSellingProducts}
+                                                        showDots={true}
+                                                />
+                                        </motion.div>
+                                </div>
+                        )}
 
-			<div className="px-10">
-				{/* Featured Products Grid */}
-				<motion.div
-					initial={{ opacity: 0, y: 20 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					className="mb-12 md:mb-16"
-				>
-					<h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
-						Featured Products
-					</h2>
+                        {hasBestSelling && (
+                                <div className="px-10">
+                                        {/* Best Selling Product */}
+                                        <FeaturedProduct product={bestSellingProduct} />
+                                </div>
+                        )}
 
-					<div className="grid grid-cols-1 lg:grid-cols-3 md:gap-6">
-						{/* First Product - vertical */}
-						<motion.div
-							initial={{ opacity: 0, y: 30 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							className="w-full col-span-1 mb-6 md:mb-0"
-						>
-							<ProductCardVarient
-								product={featuredProducts[0]}
-								variant="vertical"
-							/>
-						</motion.div>
+                        <Image
+                                src={BannerImg}
+                                alt="Banner"
+                                className="w-full h-auto mb-12 md:mb-16 object-cover"
+                        />
 
-						{/* Remaining Products - Horizontal */}
-						<div className="col-span-2 flex flex-col gap-6">
-							{featuredProducts.slice(1).map((product, index) => (
-								<motion.div
-									key={product.id}
-									initial={{ opacity: 0, y: 30 }}
-									whileInView={{ opacity: 1, y: 0 }}
-									viewport={{ once: true }}
-									transition={{ delay: index * 0.1 }}
-								>
-									<ProductCardVarient product={product} variant="horizontal" />
-								</motion.div>
-							))}
-						</div>
-					</div>
-				</motion.div>
+                        {hasFeatured && (
+                                <div className="px-10">
+                                        {/* Featured Products Grid */}
+                                        <motion.div
+                                                initial={{ opacity: 0, y: 20 }}
+                                                whileInView={{ opacity: 1, y: 0 }}
+                                                viewport={{ once: true }}
+                                                className="mb-12 md:mb-16"
+                                        >
+                                                <h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
+                                                        Featured Products
+                                                </h2>
 
-				{/* Service Guarantees */}
-				<ServiceGuarantees />
-			</div>
-		</section>
-	);
+                                                <div className="grid grid-cols-1 lg:grid-cols-3 md:gap-6">
+                                                        {/* First Product - vertical */}
+                                                        {featuredProducts[0] && (
+                                                                <motion.div
+                                                                        initial={{ opacity: 0, y: 30 }}
+                                                                        whileInView={{ opacity: 1, y: 0 }}
+                                                                        viewport={{ once: true }}
+                                                                        className="w-full col-span-1 mb-6 md:mb-0"
+                                                                >
+                                                                        <ProductCardVarient
+                                                                                product={featuredProducts[0]}
+                                                                                variant="vertical"
+                                                                        />
+                                                                </motion.div>
+                                                        )}
+
+                                                        {/* Remaining Products - Horizontal */}
+                                                        {featuredProducts.length > 1 && (
+                                                                <div className="col-span-2 flex flex-col gap-6">
+                                                                        {featuredProducts
+                                                                                .slice(1)
+                                                                                .map((product, index) => (
+                                                                                        <motion.div
+                                                                                                key={product.id}
+                                                                                                initial={{ opacity: 0, y: 30 }}
+                                                                                                whileInView={{ opacity: 1, y: 0 }}
+                                                                                                viewport={{ once: true }}
+                                                                                                transition={{ delay: index * 0.1 }}
+                                                                                        >
+                                                                                                <ProductCardVarient
+                                                                                                        product={product}
+                                                                                                        variant="horizontal"
+                                                                                                />
+                                                                                        </motion.div>
+                                                                                ))}
+                                                                </div>
+                                                        )}
+                                                </div>
+                                        </motion.div>
+                                </div>
+                        )}
+
+                        <div className="px-10">
+                                {/* Service Guarantees */}
+                                <ServiceGuarantees />
+                        </div>
+                </section>
+        );
 }

--- a/components/BuyerPanel/home/Home.jsx
+++ b/components/BuyerPanel/home/Home.jsx
@@ -82,13 +82,17 @@ export default function HomePage() {
 				onLoadMore={handleLoadMore}
 				isLoading={isLoading}
 			/>
-			<SupportSection />
+                        <SupportSection />
 
-			<FeaturedSection
-				topSellingProducts={topSellingProducts}
-				bestSellingProduct={bestSellingProduct}
-				featuredProducts={featuredProducts}
-			/>
+                        {(topSellingProducts?.length > 0 ||
+                                bestSellingProduct ||
+                                featuredProducts?.length > 0) && (
+                                <FeaturedSection
+                                        topSellingProducts={topSellingProducts}
+                                        bestSellingProduct={bestSellingProduct}
+                                        featuredProducts={featuredProducts}
+                                />
+                        )}
 
 			{/* <SearchSection
 				searchQuery={searchQuery}


### PR DESCRIPTION
## Summary
- Conditionally render the home page's `FeaturedSection` only when top selling, best selling, or featured products are available.
- Inside `FeaturedSection`, hide individual subsections when their data arrays are empty to prevent blank UI or errors.
