### PR TITLE
Fix Razorpay checkout button activation

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -43,7 +43,7 @@ import Image from "next/image";
 export default function CheckoutPage() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const [isRazorpayLoaded, setIsRazorpayLoaded] = useState(false);
+        const [isRazorpayLoaded, setIsRazorpayLoaded] = useState(false);
 	const [couponCode, setCouponCode] = useState("");
 
 	// Auth store
@@ -182,10 +182,62 @@ export default function CheckoutPage() {
 		router,
 	]);
 
-	// Handle Razorpay script load
-	const handleRazorpayLoad = useCallback(() => {
-		setIsRazorpayLoaded(true);
-	}, []);
+        // Handle Razorpay script load
+        const handleRazorpayLoad = useCallback(() => {
+                setIsRazorpayLoaded(true);
+        }, []);
+
+        const handleRazorpayError = useCallback(() => {
+                toast.error(
+                        "We couldn't load Razorpay right now. Please refresh the page or choose Cash on Delivery."
+                );
+        }, []);
+
+        useEffect(() => {
+                if (typeof window === "undefined") {
+                        return;
+                }
+
+                if (window.Razorpay) {
+                        setIsRazorpayLoaded(true);
+                        return;
+                }
+
+                let intervalId = null;
+                let timeoutId = null;
+
+                intervalId = setInterval(() => {
+                        if (window.Razorpay) {
+                                setIsRazorpayLoaded(true);
+                                if (intervalId) {
+                                        clearInterval(intervalId);
+                                }
+                                if (timeoutId) {
+                                        clearTimeout(timeoutId);
+                                }
+                        }
+                }, 300);
+
+                timeoutId = setTimeout(() => {
+                        if (!window.Razorpay) {
+                                toast.error(
+                                        "Razorpay is taking longer than expected to load. Please refresh or select Cash on Delivery."
+                                );
+                        }
+                        if (intervalId) {
+                                clearInterval(intervalId);
+                        }
+                }, 10000);
+
+                return () => {
+                        if (intervalId) {
+                                clearInterval(intervalId);
+                        }
+                        if (timeoutId) {
+                                clearTimeout(timeoutId);
+                        }
+                };
+        }, []);
 
 	// Handle address selection
 	const handleAddressSelect = useCallback(
@@ -626,14 +678,21 @@ export default function CheckoutPage() {
 						</div>
 					</div>
 
-					{paymentMethod === "razorpay" && (
-						<div className="p-4 bg-blue-50 rounded-lg">
-							<p className="text-sm text-blue-800">
-								You will be redirected to Razorpay for secure payment
-								processing.
-							</p>
-						</div>
-					)}
+                                        {paymentMethod === "razorpay" && (
+                                                <>
+                                                        <div className="p-4 bg-blue-50 rounded-lg">
+                                                                <p className="text-sm text-blue-800">
+                                                                        You will be redirected to Razorpay for secure payment
+                                                                        processing.
+                                                                </p>
+                                                        </div>
+                                                        {!isRazorpayLoaded && (
+                                                                <p className="text-sm text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-md p-3">
+                                                                        Initializing Razorpay checkout... Please wait a moment.
+                                                                </p>
+                                                        )}
+                                                </>
+                                        )}
 
 					<div className="flex gap-3">
 						<Button
@@ -644,28 +703,28 @@ export default function CheckoutPage() {
 							<ArrowLeft className="mr-2 h-4 w-4" />
 							Back
 						</Button>
-						{paymentMethod === "razorpay" && (
-							<Button
-								onClick={handlePayment}
-								disabled={
-									paymentLoading ||
-									(paymentMethod === "razorpay" && !isRazorpayLoaded)
-								}
-								className="flex-1 bg-green-600 hover:bg-green-700"
-							>
-								{paymentLoading ? (
-									<>
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-										Processing...
-									</>
-								) : (
-									<>
-										{`Pay ₹${orderSummary.total.toLocaleString()}`}
-										<ArrowRight className="ml-2 h-4 w-4" />
-									</>
-								)}
-							</Button>
-						)}
+                                                {paymentMethod === "razorpay" && (
+                                                        <Button
+                                                                onClick={handlePayment}
+                                                                disabled={
+                                                                        paymentLoading ||
+                                                                        (paymentMethod === "razorpay" && !isRazorpayLoaded)
+                                                                }
+                                                                className="flex-1 bg-green-600 hover:bg-green-700"
+                                                        >
+                                                                {paymentLoading ? (
+                                                                        <>
+                                                                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                                                                Processing...
+                                                                        </>
+                                                                ) : (
+                                                                        <>
+                                                                                {`Pay ₹${orderSummary.total.toLocaleString()}`}
+                                                                                <ArrowRight className="ml-2 h-4 w-4" />
+                                                                        </>
+                                                                )}
+                                                        </Button>
+                                                )}
 
 						{paymentMethod === "cod" && (
 							<Button
@@ -867,10 +926,13 @@ export default function CheckoutPage() {
 
 	return (
 		<>
-			<Script
-				src="https://checkout.razorpay.com/v1/checkout.js"
-				onLoad={handleRazorpayLoad}
-			/>
+                        <Script
+                                src="https://checkout.razorpay.com/v1/checkout.js"
+                                strategy="afterInteractive"
+                                onLoad={handleRazorpayLoad}
+                                onReady={handleRazorpayLoad}
+                                onError={handleRazorpayError}
+                        />
 
 			<div className="min-h-screen bg-gray-50 py-8">
 				<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- ensure the Razorpay checkout script reliably updates the payment button state
- add client-side fallbacks and user feedback while Razorpay initializes or fails to load

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9ec26ab4832ea3e56e8b4c7ba25e