### PR TITLE
Refactor order processing and add Razorpay webhook handling

### DIFF
--- a/app/api/orders/[id]/route.js
+++ b/app/api/orders/[id]/route.js
@@ -3,6 +3,7 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/lib/dbConnect.js";
 import Order from "@/model/Order.js";
+import "@/model/SubOrder.js";
 
 export async function GET(request, { params }) {
 	try {

--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -1,321 +1,116 @@
 import { NextResponse } from "next/server";
-import mongoose from "mongoose";
 import Order from "@/model/Order.js";
-import SubOrder from "@/model/SubOrder.js";
-import Product from "@/model/Product.js";
-import Cart from "@/model/Cart.js";
 import { dbConnect } from "@/lib/dbConnect.js";
-
-// Helper to calculate totals for sub-orders
-function calculateTotals(items, discountPercentage = 0) {
-	const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0);
-	const discount = (subtotal * discountPercentage) / 100;
-	const discountedSubtotal = subtotal - discount;
-	const tax = discountedSubtotal * 0.18;
-	const shippingCost = discountedSubtotal >= 500 ? 0 : 50;
-	const totalAmount = discountedSubtotal + tax + shippingCost;
-
-	return {
-		subtotal,
-		tax: Math.round(tax * 100) / 100, // Round to 2 decimal places
-		shippingCost,
-		discount: Math.round(discount * 100) / 100,
-		totalAmount: Math.round(totalAmount * 100) / 100,
-	};
-}
+import { createOrderWithSubOrders } from "@/lib/orders/createOrder.js";
 
 export async function POST(req) {
-	const session = await mongoose.startSession();
+        try {
+                await dbConnect();
 
-	try {
-		await dbConnect();
-		await session.startTransaction();
+                const body = await req.json();
+                const { orderData, userId, clearCart = false } = body;
 
-		const body = await req.json();
-		const { orderData, userId, clearCart = false } = body;
+                const { order, orderId, orderNumber, subOrderIds } = await createOrderWithSubOrders({
+                        orderData,
+                        userId,
+                        clearCart,
+                        orderStatus: orderData?.status,
+                        reserveInventory: orderData?.paymentStatus !== "failed",
+                });
 
-		// Validation
-		if (!orderData || !orderData.products?.length) {
-			throw new Error("No products in order");
-		}
+                const orderObject = order.toObject();
 
-		if (!userId) {
-			throw new Error("User  ID is required");
-		}
+                return NextResponse.json({
+                        success: true,
+                        orderId,
+                        orderNumber,
+                        order: {
+                                ...orderObject,
+                                subOrderIds,
+                        },
+                });
+        } catch (error) {
+                console.error("Order creation failed:", error.message);
+                console.error("Full error:", error);
 
-		// console.log("Starting order creation process...");
-
-		// 1️⃣ Create Parent Order
-		const orderPayload = {
-			orderNumber: `ORD-${Date.now()}-${Math.random()
-				.toString(36)
-				.substr(2, 9)}`,
-			userId,
-			customerName: orderData.customerName,
-			customerEmail: orderData.customerEmail,
-			customerMobile: orderData.customerMobile,
-			subtotal: orderData.subtotal || 0,
-			tax: orderData.tax || 0,
-			shippingCost: orderData.shippingCost || 0,
-			discount: orderData.discount || 0,
-			totalAmount: orderData.totalAmount || 0,
-			couponApplied: orderData.couponApplied || null,
-			paymentMethod: orderData.paymentMethod,
-			paymentStatus: orderData.paymentStatus || "pending",
-			transactionId: orderData.transactionId || null,
-			deliveryAddress: orderData.deliveryAddress,
-			status: "pending",
-			subOrders: [], // Initialize as empty, will be updated later
-		};
-
-		const [order] = await Order.create([orderPayload], { session });
-		// console.log("Parent Order created with ID:", order._id);
-
-		// 2️⃣ Group products by sellerId and validate stock
-		const productsBySeller = {};
-		const stockUpdates = []; // Track stock updates for rollback if needed
-
-		for (const item of orderData.products) {
-			// Fetch product with stock info
-			const product = await Product.findById(item.productId)
-				.select("sellerId stocks title")
-				.session(session);
-
-			if (!product) {
-				throw new Error(`Product not found: ${item.productId}`);
-			}
-
-			// Check stock availability
-			if (product.stocks < item.quantity) {
-				throw new Error(
-					`Insufficient stock for product: ${product.title}. Available: ${product.stocks}, Requested: ${item.quantity}`
-				);
-			}
-
-			const sellerId = product.sellerId.toString();
-
-			if (!productsBySeller[sellerId]) {
-				productsBySeller[sellerId] = [];
-			}
-
-			productsBySeller[sellerId].push({
-				...item,
-				sellerId: product.sellerId,
-				productName: product.title,
-			});
-
-			// Track stock update for this product
-			stockUpdates.push({
-				productId: item.productId,
-				quantityToDeduct: item.quantity,
-				originalStock: product.stocks,
-			});
-		}
-
-		// console.log(
-		// 	`Products grouped by ${Object.keys(productsBySeller).length} sellers`
-		// );
-
-		// 3️⃣ Update product stocks
-		const bulkOps = stockUpdates.map((update) => ({
-			updateOne: {
-				filter: { _id: update.productId },
-				update: { $inc: { stocks: -update.quantityToDeduct } },
-			},
-		}));
-
-		if (bulkOps.length > 0) {
-			await Product.bulkWrite(bulkOps, { session });
-			// console.log("Product stocks updated");
-		}
-
-		// 4️⃣ Create SubOrders for each seller
-		const subOrderData = [];
-		const subOrderIds = [];
-
-		for (const [sellerId, items] of Object.entries(productsBySeller)) {
-			const totals = calculateTotals(items);
-
-			const subOrderPayload = {
-				orderId: order._id, // Link to the parent order
-				sellerId,
-				products: items.map((item) => ({
-					productId: item.productId,
-					productName: item.productName || item.productName,
-					productImage: item.productImage || "",
-					quantity: item.quantity,
-					price: item.price,
-					totalPrice: item.totalPrice,
-				})),
-				subtotal: totals.subtotal,
-				tax: totals.tax,
-				shippingCost: totals.shippingCost,
-				discount: totals.discount,
-				totalAmount: totals.totalAmount,
-				couponApplied: orderData.couponApplied || null,
-				status: "pending",
-			};
-
-			subOrderData.push(subOrderPayload);
-		}
-
-		// Create all suborders in batch
-		const createdSubOrders = await SubOrder.create(subOrderData, { session });
-		createdSubOrders.forEach((subOrder) => {
-			// Ensure the ID is a Mongoose ObjectId
-			subOrderIds.push(new mongoose.Types.ObjectId(subOrder._id));
-		});
-
-		// console.log(
-		// 	`${createdSubOrders.length} SubOrders created. IDs:`,
-		// 	subOrderIds
-		// );
-
-		// 5️⃣ Update parent order with subOrder IDs
-		if (subOrderIds.length > 0) {
-			const updatedOrder = await Order.findByIdAndUpdate(
-				order._id,
-				{ $set: { subOrders: subOrderIds } },
-				{
-					new: true,
-					runValidators: true,
-					session,
-				}
-			);
-			// console.log(
-			// 	"Parent order updated with subOrders. Count:",
-			// 	updatedOrder.subOrders.length
-			// );
-			// console.log(
-			// 	"Updated parent order's subOrders array:",
-			// 	updatedOrder.subOrders
-			// );
-		} else {
-			console.log("No subOrders to update in parent order.");
-		}
-
-		// 6️⃣ Clear cart if requested
-		if (clearCart && userId) {
-			await Cart.findOneAndUpdate(
-				{ user: userId },
-				{
-					products: [],
-					totalPrice: 0,
-					appliedPromo: null,
-				},
-				{ session }
-			);
-			console.log("Cart cleared for user:", userId);
-		}
-
-		// Commit transaction
-		await session.commitTransaction();
-		// console.log("Order creation completed successfully");
-
-		// Fetch the final order to ensure subOrders are populated for the response
-		const finalOrder = await Order.findById(order._id)
-			.populate("subOrders")
-			.session(session);
-
-		console.log("Final order data:", finalOrder);
-
-		return NextResponse.json({
-			success: true,
-			orderId: finalOrder._id,
-			orderNumber: finalOrder.orderNumber,
-			order: {
-				...finalOrder.toObject(),
-				subOrderIds: finalOrder.subOrders?.map((sub) => sub._id) || [],
-			},
-		});
-	} catch (error) {
-		// Rollback transaction on error
-		await session.abortTransaction();
-		console.error("Order creation failed:", error.message);
-		console.error("Full error:", error);
-
-		return NextResponse.json(
-			{
-				success: false,
-				error: error.message,
-				details:
-					process.env.NODE_ENV === "development" ? error.stack : undefined,
-			},
-			{ status: 500 }
-		);
-	} finally {
-		// End session
-		await session.endSession();
-	}
+                return NextResponse.json(
+                        {
+                                success: false,
+                                error: error.message,
+                                details:
+                                        process.env.NODE_ENV === "development" ? error.stack : undefined,
+                        },
+                        { status: 500 }
+                );
+        }
 }
 
-// GET function remains unchanged
 export async function GET(req) {
-	try {
-		await dbConnect();
+        try {
+                await dbConnect();
 
-		const { searchParams } = new URL(req.url);
-		const userId = searchParams.get("userId");
-		const orderId = searchParams.get("orderId");
-		const page = parseInt(searchParams.get("page") || "1");
-		const limit = parseInt(searchParams.get("limit") || "10");
+                const { searchParams } = new URL(req.url);
+                const userId = searchParams.get("userId");
+                const orderId = searchParams.get("orderId");
+                const page = parseInt(searchParams.get("page") || "1");
+                const limit = parseInt(searchParams.get("limit") || "10");
 
-		// Build query
-		const query = {};
-		if (userId) query.userId = userId;
-		if (orderId) query._id = orderId;
+                // Build query
+                const query = {};
+                if (userId) query.userId = userId;
+                if (orderId) query._id = orderId;
 
-		const skip = (page - 1) * limit;
+                const skip = (page - 1) * limit;
 
-		// Fetch orders with populated subOrders
-		const orders = await Order.find(query)
-			.sort({ createdAt: -1 })
-			.skip(skip)
-			.limit(limit)
-			.populate({
-				path: "subOrders",
-				populate: [
-					{
-						path: "products.productId",
-						select: "title images price category",
-					},
-					{
-						path: "sellerId",
-						select: "name email businessName",
-					},
-				],
-			})
-			.lean();
+                // Fetch orders with populated subOrders
+                const orders = await Order.find(query)
+                        .sort({ createdAt: -1 })
+                        .skip(skip)
+                        .limit(limit)
+                        .populate({
+                                path: "subOrders",
+                                populate: [
+                                        {
+                                                path: "products.productId",
+                                                select: "title images price category",
+                                        },
+                                        {
+                                                path: "sellerId",
+                                                select: "name email businessName",
+                                        },
+                                ],
+                        })
+                        .lean();
 
-		const total = await Order.countDocuments(query);
+                const total = await Order.countDocuments(query);
 
-		const ordersWithDebug = orders.map((order) => ({
-			...order,
-			subOrdersCount: order.subOrders?.length || 0,
-			hasSubOrders: Boolean(order.subOrders?.length),
-		}));
+                const ordersWithDebug = orders.map((order) => ({
+                        ...order,
+                        subOrdersCount: order.subOrders?.length || 0,
+                        hasSubOrders: Boolean(order.subOrders?.length),
+                }));
 
-		return NextResponse.json({
-			success: true,
-			orders: ordersWithDebug,
-			pagination: {
-				currentPage: page,
-				totalPages: Math.ceil(total / limit),
-				totalOrders: total,
-				hasNextPage: page < Math.ceil(total / limit),
-				hasPrevPage: page > 1,
-			},
-		});
-	} catch (error) {
-		console.error("Orders fetch error:", error);
-		return NextResponse.json(
-			{
-				success: false,
-				error: error.message,
-				details:
-					process.env.NODE_ENV === "development" ? error.stack : undefined,
-			},
-			{ status: 500 }
-		);
-	}
+                return NextResponse.json({
+                        success: true,
+                        orders: ordersWithDebug,
+                        pagination: {
+                                currentPage: page,
+                                totalPages: Math.ceil(total / limit),
+                                totalOrders: total,
+                                hasNextPage: page < Math.ceil(total / limit),
+                                hasPrevPage: page > 1,
+                        },
+                });
+        } catch (error) {
+                console.error("Orders fetch error:", error);
+                return NextResponse.json(
+                        {
+                                success: false,
+                                error: error.message,
+                                details:
+                                        process.env.NODE_ENV === "development" ? error.stack : undefined,
+                        },
+                        { status: 500 }
+                );
+        }
 }

--- a/app/api/orders/send-confirmation/route.js
+++ b/app/api/orders/send-confirmation/route.js
@@ -2,214 +2,85 @@
 import { NextResponse } from "next/server";
 import User from "@/model/User";
 import { dbConnect } from "@/lib/dbConnect.js";
-import { sendMail } from "@/lib/mail";
 import { companyInfo } from "@/constants/companyInfo.js";
+import { sendOrderConfirmationEmail } from "@/lib/orders/email.js";
 
 export async function POST(req) {
-	try {
-		await dbConnect();
+        try {
+                await dbConnect();
 
-		const body = await req.json();
-		const { orderData, userId, pdfBase64 } = body; // Added pdfBase64 parameter
+                const body = await req.json();
+                const { orderData, userId, pdfBase64 } = body;
 
-		// console.log("orderData from send-confirmation:", orderData);
+                if (!orderData || !userId) {
+                        return NextResponse.json(
+                                { success: false, error: "Order data and user ID are required" },
+                                { status: 400 }
+                        );
+                }
 
-		if (!orderData || !userId) {
-			return NextResponse.json(
-				{ success: false, error: "Order data and user ID are required" },
-				{ status: 400 }
-			);
-		}
+                const user = await User.findById(userId).select(
+                        "email firstName notificationPreferences"
+                );
 
-		// Get user information
-		const user = await User.findById(userId).select(
-			"email firstName notificationPreferences"
-		);
+                if (!user) {
+                        return NextResponse.json(
+                                { success: false, error: "User not found" },
+                                { status: 404 }
+                        );
+                }
 
-		if (!user) {
-			return NextResponse.json(
-				{ success: false, error: "User not found" },
-				{ status: 404 }
-			);
-		}
+                const prefs = user?.notificationPreferences;
+                const emailOptOut =
+                        prefs?.channels?.email === false ||
+                        prefs?.settings?.["order-placed"]?.email === false;
 
-		// Check if user has opted out of email notifications
-		const prefs = user?.notificationPreferences;
-		const emailOptOut =
-			prefs?.channels?.email === false ||
-			prefs?.settings?.["order-placed"]?.email === false;
+                if (emailOptOut) {
+                        return NextResponse.json({
+                                success: true,
+                                message: "User opted out of email notifications",
+                                emailSent: false,
+                        });
+                }
 
-		if (emailOptOut) {
-			return NextResponse.json({
-				success: true,
-				message: "User opted out of email notifications",
-				emailSent: false,
-			});
-		}
+                const orderForEmail = {
+                        ...orderData,
+                        customerEmail: orderData.customerEmail || user.email,
+                        customerName: orderData.customerName || user.firstName,
+                };
 
-		// Format currency helper
-		const formatCurrency = (value) =>
-			`₹${value.toLocaleString("en-IN", {
-				minimumFractionDigits: 2,
-				maximumFractionDigits: 2,
-			})}`;
+                try {
+                        const emailResult = await sendOrderConfirmationEmail({
+                                order: orderForEmail,
+                                to: user.email,
+                                cc: companyInfo.adminEmail ? [companyInfo.adminEmail] : undefined,
+                                pdfBase64,
+                                attachInvoice: !pdfBase64,
+                        });
 
-		// Generate items HTML for email
-		const itemsHtml = orderData.products
-			.map(
-				(item) => `
-				<tr>
-					<td style="padding:8px;border:1px solid #e5e7eb;">${item.productName}</td>
-					<td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${
-						item.quantity
-					}</td>
-					<td style="padding:8px;border:1px solid #e5e7eb;text-align:right;">${formatCurrency(
-						item.totalPrice
-					)}</td>
-				</tr>`
-			)
-			.join("");
-
-		// Get shipping address
-		const address = orderData.deliveryAddress;
-		// orderData.shipToAddress ||
-		// orderData.billToAddress ||
-
-		// Generate email HTML
-		const html = `
-			<div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333;">
-				<h2 style="color:#4f46e5;">Thank you for your order!</h2>
-				<p>Hi ${user.firstName},</p>
-				<p>Your order <strong>${
-					orderData.orderNumber
-				}</strong> has been placed successfully on ${new Date(
-			orderData.orderDate
-		).toLocaleDateString()}.</p>
-				
-				<h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Order Summary</h3>
-				<table style="width:100%;border-collapse:collapse;">
-					<thead>
-						<tr style="background:#f3f4f6;">
-							<th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Product</th>
-							<th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Qty</th>
-							<th style="padding:8px;border:1px solid #e5e7eb;text-align:right;">Total</th>
-						</tr>
-					</thead>
-					<tbody>
-						${itemsHtml}
-					</tbody>
-				</table>
-				
-				<table style="width:100%;margin-top:8px;">
-					<tr>
-						<td style="text-align:right;padding:4px;">Subtotal:</td>
-						<td style="text-align:right;padding:4px;">${formatCurrency(
-							orderData.subtotal
-						)}</td>
-					</tr>
-					${
-						orderData.gst &&
-						orderData.gst.cgst + orderData.gst.sgst + orderData.gst.igst > 0
-							? `<tr><td style="text-align:right;padding:4px;">GST:</td><td style="text-align:right;padding:4px;">${formatCurrency(
-									orderData.gst.cgst + orderData.gst.sgst + orderData.gst.igst
-							  )}</td></tr>`
-							: ""
-					}
-					${
-						orderData.shippingCost > 0
-							? `<tr><td style="text-align:right;padding:4px;">Shipping:</td><td style="text-align:right;padding:4px;">${formatCurrency(
-									orderData.shippingCost
-							  )}</td></tr>`
-							: ""
-					}
-					${
-						orderData.discount > 0
-							? `<tr><td style="text-align:right;padding:4px;">Discount:</td><td style="text-align:right;padding:4px;">-${formatCurrency(
-									orderData.discount
-							  )}</td></tr>`
-							: ""
-					}
-					<tr>
-						<td style="text-align:right;padding:4px;font-weight:bold;">Total:</td>
-						<td style="text-align:right;padding:4px;font-weight:bold;">${formatCurrency(
-							orderData.totalAmount
-						)}</td>
-					</tr>
-				</table>
-				
-				<h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Shipping Address</h3>
-				<p style="margin:0;">${address.name || ""}</p>
-				<p style="margin:0;">${address.street || ""}</p>
-				<p style="margin:0;">${address.city || ""}, ${address.state || ""} - ${
-			address.zipCode || ""
-		}</p>
-				<p style="margin:0;">${address.country || ""}</p>
-				
-				<p style="margin-top:24px;">Your invoice is attached as a PDF for your records.</p>
-				<p>If you have any questions, reply to this email or contact us at ${
-					companyInfo.email
-				}.</p>
-				<p style="margin-top:16px;">Best regards,<br/>${
-					companyInfo.name || companyInfo.companyName || "Team"
-				}</p>
-			</div>
-		`;
-
-		// Prepare attachments with client-generated PDF
-		const attachments = [];
-		let pdfError = null;
-
-		if (pdfBase64) {
-			try {
-				// Convert base64 to buffer
-				const pdfBuffer = Buffer.from(pdfBase64, "base64");
-				attachments.push({
-					filename: `invoice-${orderData.orderNumber}.pdf`,
-					content: pdfBuffer,
-					contentType: "application/pdf",
-				});
-			} catch (error) {
-				console.error("Failed to process client-generated PDF:", error);
-				pdfError = error.message;
-			}
-		} else {
-			pdfError = "No PDF provided by client";
-		}
-
-		// Send email
-		try {
-			await sendMail({
-				to: [user.email],
-				cc: companyInfo.adminEmail ? [companyInfo.adminEmail] : undefined,
-				subject: `Order Confirmed - ${orderData.orderNumber}`,
-				html,
-				attachments: attachments.length > 0 ? attachments : undefined,
-			});
-
-			return NextResponse.json({
-				success: true,
-				message: "Order confirmation email sent successfully",
-				emailSent: true,
-				pdfAttached: attachments.length > 0,
-				pdfError: pdfError,
-			});
-		} catch (mailError) {
-			console.error("Failed to send order confirmation email:", mailError);
-			return NextResponse.json(
-				{
-					success: false,
-					error: "Failed to send email",
-					details: mailError.message,
-					pdfError: pdfError,
-				},
-				{ status: 500 }
-			);
-		}
-	} catch (error) {
-		console.error("Email confirmation error:", error);
-		return NextResponse.json(
-			{ success: false, error: error.message },
-			{ status: 500 }
-		);
-	}
+                        return NextResponse.json({
+                                success: true,
+                                message: "Order confirmation email sent successfully",
+                                emailSent: true,
+                                pdfAttached: emailResult.pdfAttached,
+                                pdfError: emailResult.pdfError,
+                        });
+                } catch (mailError) {
+                        console.error("Failed to send order confirmation email:", mailError);
+                        return NextResponse.json(
+                                {
+                                        success: false,
+                                        error: "Failed to send email",
+                                        details: mailError.message,
+                                },
+                                { status: 500 }
+                        );
+                }
+        } catch (error) {
+                console.error("Email confirmation error:", error);
+                return NextResponse.json(
+                        { success: false, error: error.message },
+                        { status: 500 }
+                );
+        }
 }

--- a/app/api/paymentverify/route.js
+++ b/app/api/paymentverify/route.js
@@ -1,72 +1,247 @@
-// import crypto from "crypto";
+import crypto from "crypto";
 import { NextResponse } from "next/server";
-import Order from "@/model/Order";
-import Product from "@/model/Product";
-import Cart from "@/model/Cart";
+
 import { dbConnect } from "@/lib/dbConnect.js";
+import Order from "@/model/Order";
+import { createOrderWithSubOrders } from "@/lib/orders/createOrder.js";
+import {
+        sendOrderConfirmationEmail,
+        sendOrderFailureEmail,
+} from "@/lib/orders/email.js";
+import { companyInfo } from "@/constants/companyInfo.js";
+
+async function getPopulatedOrder(filter) {
+        return Order.findOne(filter).populate({
+                path: "subOrders",
+                populate: [
+                        {
+                                path: "products.productId",
+                                select: "title images price category",
+                        },
+                        {
+                                path: "sellerId",
+                                select: "name email businessName",
+                        },
+                ],
+        });
+}
 
 export async function POST(req) {
-	try {
-		await dbConnect();
+        try {
+                await dbConnect();
 
-		const body = await req.json();
-		const {
-			// razorpay_order_id,
-			razorpay_payment_id,
-			// razorpay_signature,
-			orderData,
-			userId,
-			clearCart = false,
-		} = body;
+                const body = await req.json();
+                const {
+                        razorpay_order_id,
+                        razorpay_payment_id,
+                        razorpay_signature,
+                        orderData,
+                        userId,
+                        clearCart = false,
+                        status = "success",
+                        failureReason,
+                } = body;
 
-		// // Verify signature
-		// const hmac = crypto.createHmac("sha256", process.env.RAZORPAY_KEY_SECRET);
-		// hmac.update(razorpay_order_id + "|" + razorpay_payment_id);
-		// const generatedSignature = hmac.digest("hex");
+                if (!orderData || !Array.isArray(orderData.products) || orderData.products.length === 0) {
+                        return NextResponse.json(
+                                { success: false, error: "Order data with products is required" },
+                                { status: 400 }
+                        );
+                }
 
-		// if (generatedSignature !== razorpay_signature) {
-		// 	return NextResponse.json(
-		// 		{ success: false, error: "Invalid payment signature" },
-		// 		{ status: 400 }
-		// 	);
-		// }
+                if (!userId) {
+                        return NextResponse.json(
+                                { success: false, error: "User ID is required" },
+                                { status: 400 }
+                        );
+                }
 
-		// Create order in database
-		const order = new Order({
-			...orderData,
-			transactionId: razorpay_payment_id,
-			paymentStatus: "paid",
-			status: "confirmed",
-		});
+                const adminCc = companyInfo.adminEmail ? [companyInfo.adminEmail] : undefined;
 
-		await order.save();
+                if (status === "failed") {
+                        if (!razorpay_order_id) {
+                                return NextResponse.json(
+                                        { success: false, error: "Missing Razorpay order id for failure" },
+                                        { status: 400 }
+                                );
+                        }
 
-		// Update product stocks
-		for (const item of orderData.products) {
-			await Product.findByIdAndUpdate(item.productId, {
-				$inc: { stocks: -item.quantity },
-			});
-		}
+                        const failureMessage =
+                                failureReason || "The payment could not be completed. No amount was captured.";
 
-		// Clear cart if it's a cart checkout
-		if (clearCart && userId) {
-			await Cart.findOneAndUpdate(
-				{ user: userId },
-				{ products: [], totalPrice: 0, appliedPromo: null }
-			);
-		}
+                        const existingOrder = await getPopulatedOrder({
+                                paymentGatewayOrderId: razorpay_order_id,
+                        });
 
-		return NextResponse.json({
-			success: true,
-			orderId: order._id,
-			orderNumber: order.orderNumber,
-			order: order,
-		});
-	} catch (error) {
-		console.error("Payment verification error:", error);
-		return NextResponse.json(
-			{ success: false, error: error.message },
-			{ status: 500 }
-		);
-	}
+                        if (existingOrder) {
+                                if (existingOrder.paymentStatus !== "failed") {
+                                        existingOrder.paymentStatus = "failed";
+                                        existingOrder.status = "cancelled";
+                                        existingOrder.paymentFailureReason = failureMessage;
+                                        if (razorpay_payment_id) {
+                                                existingOrder.transactionId = razorpay_payment_id;
+                                        }
+                                        await existingOrder.save();
+                                }
+
+                                try {
+                                        await sendOrderFailureEmail({
+                                                order: existingOrder,
+                                                to: existingOrder.customerEmail,
+                                                cc: adminCc,
+                                                failureReason: failureMessage,
+                                        });
+                                } catch (emailError) {
+                                        console.error("Payment failure email error:", emailError);
+                                }
+
+                                return NextResponse.json({
+                                        success: false,
+                                        status: "failed",
+                                        message: failureMessage,
+                                        orderId: existingOrder._id,
+                                        orderNumber: existingOrder.orderNumber,
+                                });
+                        }
+
+                        const { order, orderId, orderNumber } = await createOrderWithSubOrders({
+                                orderData: {
+                                        ...orderData,
+                                        paymentStatus: "failed",
+                                        status: "cancelled",
+                                        paymentFailureReason: failureMessage,
+                                },
+                                userId,
+                                clearCart: false,
+                                paymentInfo: {
+                                        paymentStatus: "failed",
+                                        transactionId: razorpay_payment_id || null,
+                                        gatewayOrderId: razorpay_order_id,
+                                        paymentFailureReason: failureMessage,
+                                },
+                                orderStatus: "cancelled",
+                                subOrderStatus: "cancelled",
+                                reserveInventory: false,
+                        });
+
+                        try {
+                                await sendOrderFailureEmail({
+                                        order,
+                                        to: order.customerEmail || orderData.customerEmail,
+                                        cc: adminCc,
+                                        failureReason: failureMessage,
+                                });
+                        } catch (emailError) {
+                                console.error("Payment failure email error:", emailError);
+                        }
+
+                        return NextResponse.json({
+                                success: false,
+                                status: "failed",
+                                message: failureMessage,
+                                orderId,
+                                orderNumber,
+                        });
+                }
+
+                if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature) {
+                        return NextResponse.json(
+                                { success: false, error: "Incomplete Razorpay payment details" },
+                                { status: 400 }
+                        );
+                }
+
+                if (!process.env.RAZORPAY_KEY_SECRET) {
+                        throw new Error("Razorpay key secret is not configured");
+                }
+
+                const hmac = crypto.createHmac("sha256", process.env.RAZORPAY_KEY_SECRET);
+                hmac.update(`${razorpay_order_id}|${razorpay_payment_id}`);
+                const generatedSignature = hmac.digest("hex");
+
+                if (generatedSignature !== razorpay_signature) {
+                        return NextResponse.json(
+                                { success: false, error: "Invalid payment signature" },
+                                { status: 400 }
+                        );
+                }
+
+                let existingOrder = await getPopulatedOrder({
+                        paymentGatewayOrderId: razorpay_order_id,
+                });
+
+                if (existingOrder) {
+                        if (existingOrder.paymentStatus !== "paid") {
+                                existingOrder.paymentStatus = "paid";
+                                existingOrder.status = "confirmed";
+                                existingOrder.paymentFailureReason = null;
+                                existingOrder.transactionId = razorpay_payment_id;
+                                await existingOrder.save();
+                                existingOrder = await getPopulatedOrder({ _id: existingOrder._id });
+                        }
+
+                        try {
+                                await sendOrderConfirmationEmail({
+                                        order: existingOrder,
+                                        to: existingOrder.customerEmail,
+                                        cc: adminCc,
+                                        attachInvoice: true,
+                                });
+                        } catch (emailError) {
+                                console.error("Order confirmation email error:", emailError);
+                        }
+
+                        return NextResponse.json({
+                                success: true,
+                                orderId: existingOrder._id,
+                                orderNumber: existingOrder.orderNumber,
+                                order: existingOrder,
+                        });
+                }
+
+                const { order, orderId, orderNumber, subOrderIds } = await createOrderWithSubOrders({
+                        orderData: {
+                                ...orderData,
+                                paymentStatus: "paid",
+                                status: "confirmed",
+                        },
+                        userId,
+                        clearCart,
+                        paymentInfo: {
+                                paymentStatus: "paid",
+                                transactionId: razorpay_payment_id,
+                                gatewayOrderId: razorpay_order_id,
+                        },
+                        orderStatus: "confirmed",
+                });
+
+                const orderObject = order.toObject();
+
+                try {
+                        await sendOrderConfirmationEmail({
+                                order: orderObject,
+                                to: orderObject.customerEmail || orderData.customerEmail,
+                                cc: adminCc,
+                                attachInvoice: true,
+                        });
+                } catch (emailError) {
+                        console.error("Order confirmation email error:", emailError);
+                }
+
+                return NextResponse.json({
+                        success: true,
+                        orderId,
+                        orderNumber,
+                        order: {
+                                ...orderObject,
+                                subOrderIds,
+                        },
+                });
+        } catch (error) {
+                console.error("Payment verification error:", error);
+                return NextResponse.json(
+                        { success: false, error: error.message },
+                        { status: 500 }
+                );
+        }
 }

--- a/app/api/razorpay/webhook/route.js
+++ b/app/api/razorpay/webhook/route.js
@@ -1,0 +1,186 @@
+import crypto from "crypto";
+import { NextResponse } from "next/server";
+
+import { dbConnect } from "@/lib/dbConnect.js";
+import Order from "@/model/Order.js";
+import {
+        sendOrderConfirmationEmail,
+        sendOrderFailureEmail,
+} from "@/lib/orders/email.js";
+import { companyInfo } from "@/constants/companyInfo.js";
+
+async function updateOrderAndNotify(order, update, notification) {
+        const adminCc = companyInfo.adminEmail ? [companyInfo.adminEmail] : undefined;
+        const updatedOrder = await Order.findByIdAndUpdate(order._id, update, {
+                new: true,
+        }).populate({
+                path: "subOrders",
+                populate: [
+                        {
+                                path: "products.productId",
+                                select: "title images price category",
+                        },
+                        {
+                                path: "sellerId",
+                                select: "name email businessName",
+                        },
+                ],
+        });
+
+        if (!updatedOrder) {
+                return null;
+        }
+
+        try {
+                if (notification?.type === "success") {
+                        await sendOrderConfirmationEmail({
+                                order: updatedOrder,
+                                to: updatedOrder.customerEmail,
+                                cc: adminCc,
+                                attachInvoice: true,
+                        });
+                } else if (notification?.type === "failure") {
+                        await sendOrderFailureEmail({
+                                order: updatedOrder,
+                                to: updatedOrder.customerEmail,
+                                cc: adminCc,
+                                failureReason: notification?.reason,
+                        });
+                }
+        } catch (emailError) {
+                console.error("Webhook notification email error:", emailError);
+        }
+
+        return updatedOrder;
+}
+
+export async function POST(req) {
+        try {
+                const rawBody = await req.text();
+
+                const signature = req.headers.get("x-razorpay-signature");
+                if (!signature) {
+                        return NextResponse.json(
+                                { success: false, error: "Missing webhook signature" },
+                                { status: 400 }
+                        );
+                }
+
+                const webhookSecret = process.env.RAZORPAY_WEBHOOK_SECRET;
+                if (!webhookSecret) {
+                        console.error("Razorpay webhook secret is not configured");
+                        return NextResponse.json(
+                                { success: false, error: "Webhook secret not configured" },
+                                { status: 500 }
+                        );
+                }
+
+                const expectedSignature = crypto
+                        .createHmac("sha256", webhookSecret)
+                        .update(rawBody)
+                        .digest("hex");
+
+                if (expectedSignature !== signature) {
+                        return NextResponse.json(
+                                { success: false, error: "Invalid webhook signature" },
+                                { status: 400 }
+                        );
+                }
+
+                const payload = JSON.parse(rawBody);
+
+                await dbConnect();
+
+                const event = payload?.event;
+
+                if (!event) {
+                        return NextResponse.json({ success: false, error: "Missing event type" }, { status: 400 });
+                }
+
+                if (event === "payment.captured" || event === "order.paid") {
+                        const paymentEntity = payload?.payload?.payment?.entity;
+                        const orderEntity = payload?.payload?.order?.entity;
+
+                        const razorpayOrderId = paymentEntity?.order_id || orderEntity?.id;
+                        const paymentId = paymentEntity?.id;
+
+                        if (!razorpayOrderId) {
+                                return NextResponse.json({
+                                        success: true,
+                                        message: "No Razorpay order id in webhook",
+                                });
+                        }
+
+                        const order = await Order.findOne({ paymentGatewayOrderId: razorpayOrderId });
+
+                        if (!order) {
+                                console.warn("Webhook: order not found for", razorpayOrderId);
+                                return NextResponse.json({ success: true, message: "Order not found" });
+                        }
+
+                        if (order.paymentStatus === "paid") {
+                                return NextResponse.json({ success: true, message: "Order already marked paid" });
+                        }
+
+                        await updateOrderAndNotify(
+                                order,
+                                {
+                                        paymentStatus: "paid",
+                                        status: order.status === "pending" ? "confirmed" : order.status,
+                                        transactionId: paymentId || order.transactionId,
+                                        paymentFailureReason: null,
+                                },
+                                { type: "success" }
+                        );
+
+                        return NextResponse.json({ success: true });
+                }
+
+                if (event === "payment.failed") {
+                        const paymentEntity = payload?.payload?.payment?.entity;
+                        const razorpayOrderId = paymentEntity?.order_id;
+                        const failureReason =
+                                paymentEntity?.error_description ||
+                                paymentEntity?.description ||
+                                paymentEntity?.error_reason ||
+                                "Payment failed";
+
+                        if (!razorpayOrderId) {
+                                return NextResponse.json({ success: true, message: "No order id for failure" });
+                        }
+
+                        const order = await Order.findOne({ paymentGatewayOrderId: razorpayOrderId });
+
+                        if (!order) {
+                                console.warn("Webhook: failure for unknown order", razorpayOrderId);
+                                return NextResponse.json({ success: true, message: "Order not found" });
+                        }
+
+                        if (order.paymentStatus === "failed") {
+                                return NextResponse.json({ success: true, message: "Order already marked failed" });
+                        }
+
+                        await updateOrderAndNotify(
+                                order,
+                                {
+                                        paymentStatus: "failed",
+                                        status: "cancelled",
+                                        paymentFailureReason: failureReason,
+                                },
+                                { type: "failure", reason: failureReason }
+                        );
+
+                        return NextResponse.json({ success: true });
+                }
+
+                return NextResponse.json({ success: true, message: `Unhandled event ${event}` });
+        } catch (error) {
+                console.error("Razorpay webhook error:", error);
+                return NextResponse.json(
+                        { success: false, error: error.message },
+                        { status: 500 }
+                );
+        }
+}
+
+export const dynamic = "force-dynamic";

--- a/lib/orders/createOrder.js
+++ b/lib/orders/createOrder.js
@@ -1,0 +1,237 @@
+import mongoose from "mongoose";
+
+import Order from "@/model/Order.js";
+import SubOrder from "@/model/SubOrder.js";
+import Product from "@/model/Product.js";
+import Cart from "@/model/Cart.js";
+
+function calculateTotals(items, discountPercentage = 0) {
+        const subtotal = items.reduce((sum, item) => sum + (item.totalPrice || 0), 0);
+        const discount = (subtotal * discountPercentage) / 100;
+        const discountedSubtotal = subtotal - discount;
+        const tax = discountedSubtotal * 0.18;
+        const shippingCost = discountedSubtotal >= 500 ? 0 : 50;
+        const totalAmount = discountedSubtotal + tax + shippingCost;
+
+        return {
+                subtotal,
+                tax: Math.round(tax * 100) / 100,
+                shippingCost,
+                discount: Math.round(discount * 100) / 100,
+                totalAmount: Math.round(totalAmount * 100) / 100,
+        };
+}
+
+function normalizeNumber(value, fallback = 0) {
+        if (value === null || value === undefined || Number.isNaN(Number(value))) {
+                return fallback;
+        }
+        return Number(value);
+}
+
+export async function createOrderWithSubOrders({
+        orderData,
+        userId,
+        clearCart = false,
+        paymentInfo = {},
+        orderStatus,
+        subOrderStatus,
+        reserveInventory = true,
+} = {}) {
+        if (!orderData || !Array.isArray(orderData.products) || orderData.products.length === 0) {
+                throw new Error("No products in order");
+        }
+
+        if (!userId) {
+                throw new Error("User ID is required");
+        }
+
+        if (!orderData.paymentMethod) {
+                throw new Error("Payment method is required for order creation");
+        }
+
+        const session = await mongoose.startSession();
+
+        try {
+                await session.startTransaction();
+
+                const effectiveOrderStatus =
+                        orderStatus || orderData.status || (reserveInventory ? "pending" : "cancelled");
+                const effectiveSubOrderStatus =
+                        subOrderStatus || orderData.subOrderStatus || (reserveInventory ? "pending" : "cancelled");
+                const effectivePaymentStatus =
+                        paymentInfo.paymentStatus ||
+                        orderData.paymentStatus ||
+                        (reserveInventory ? "pending" : "failed");
+
+                const paymentFailureReason =
+                        paymentInfo.paymentFailureReason || orderData.paymentFailureReason || null;
+
+                const orderPayload = {
+                        orderNumber:
+                                orderData.orderNumber ||
+                                `ORD-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+                        userId,
+                        customerName: orderData.customerName,
+                        customerEmail: orderData.customerEmail,
+                        customerMobile: orderData.customerMobile,
+                        subtotal: normalizeNumber(orderData.subtotal),
+                        tax: normalizeNumber(orderData.tax),
+                        shippingCost: normalizeNumber(orderData.shippingCost),
+                        discount: normalizeNumber(orderData.discount),
+                        totalAmount: normalizeNumber(orderData.totalAmount),
+                        couponApplied: orderData.couponApplied || null,
+                        paymentMethod: orderData.paymentMethod,
+                        paymentStatus: effectivePaymentStatus,
+                        transactionId: paymentInfo.transactionId || orderData.transactionId || null,
+                        paymentGatewayOrderId:
+                                paymentInfo.gatewayOrderId || orderData.paymentGatewayOrderId || null,
+                        paymentFailureReason,
+                        deliveryAddress: orderData.deliveryAddress,
+                        status: effectiveOrderStatus,
+                        subOrders: [],
+                };
+
+                const [order] = await Order.create([orderPayload], { session });
+
+                const productsBySeller = new Map();
+                const stockUpdates = [];
+
+                for (const item of orderData.products) {
+                        const product = await Product.findById(item.productId)
+                                .select("sellerId stocks title price images")
+                                .session(session);
+
+                        if (!product) {
+                                if (reserveInventory) {
+                                        throw new Error(`Product not found: ${item.productId}`);
+                                }
+                        } else if (reserveInventory) {
+                                if (product.stocks < item.quantity) {
+                                        throw new Error(
+                                                `Insufficient stock for product: ${product.title}. Available: ${product.stocks}, Requested: ${item.quantity}`
+                                        );
+                                }
+
+                                stockUpdates.push({
+                                        productId: item.productId,
+                                        quantityToDeduct: item.quantity,
+                                });
+                        }
+
+                        const sellerId =
+                                product?.sellerId?.toString() || item.sellerId?.toString() || null;
+
+                        if (!sellerId) {
+                                throw new Error(`Seller information missing for product: ${item.productId}`);
+                        }
+
+                        const existingItems = productsBySeller.get(sellerId) || [];
+                        existingItems.push({
+                                ...item,
+                                sellerId: product?.sellerId || item.sellerId,
+                                productName: item.productName || product?.title || "Unknown Product",
+                                productImage: item.productImage || item.image || product?.images?.[0] || "",
+                                price: normalizeNumber(item.price ?? product?.price),
+                                totalPrice: normalizeNumber(
+                                        item.totalPrice ??
+                                                (item.quantity || 0) * normalizeNumber(item.price ?? product?.price)
+                                ),
+                        });
+                        productsBySeller.set(sellerId, existingItems);
+                }
+
+                if (reserveInventory && stockUpdates.length > 0) {
+                        const bulkOps = stockUpdates.map((update) => ({
+                                updateOne: {
+                                        filter: { _id: update.productId },
+                                        update: { $inc: { stocks: -update.quantityToDeduct } },
+                                },
+                        }));
+
+                        await Product.bulkWrite(bulkOps, { session });
+                }
+
+                const subOrderPayloads = [];
+
+                for (const [sellerKey, items] of productsBySeller.entries()) {
+                        const totals = calculateTotals(items);
+
+                        const sellerObjectId = mongoose.Types.ObjectId.isValid(sellerKey)
+                                ? new mongoose.Types.ObjectId(sellerKey)
+                                : items[0]?.sellerId || undefined;
+
+                        subOrderPayloads.push({
+                                orderId: order._id,
+                                sellerId: sellerObjectId,
+                                products: items.map((item) => ({
+                                        productId: item.productId,
+                                        productName: item.productName,
+                                        productImage: item.productImage || "",
+                                        quantity: item.quantity,
+                                        price: normalizeNumber(item.price),
+                                        totalPrice: normalizeNumber(item.totalPrice),
+                                })),
+                                subtotal: totals.subtotal,
+                                tax: totals.tax,
+                                shippingCost: totals.shippingCost,
+                                discount: totals.discount,
+                                totalAmount: totals.totalAmount,
+                                couponApplied: orderData.couponApplied || null,
+                                status: effectiveSubOrderStatus,
+                        });
+                }
+
+                const createdSubOrders = subOrderPayloads.length
+                        ? await SubOrder.create(subOrderPayloads, { session })
+                        : [];
+
+                const subOrderIds = createdSubOrders.map((subOrder) => subOrder._id);
+
+                if (subOrderIds.length > 0) {
+                        await Order.findByIdAndUpdate(
+                                order._id,
+                                { $set: { subOrders: subOrderIds } },
+                                { session, new: true }
+                        );
+                }
+
+                if (clearCart && userId) {
+                        await Cart.findOneAndUpdate(
+                                { user: userId },
+                                { products: [], totalPrice: 0, appliedPromo: null },
+                                { session }
+                        );
+                }
+
+                await session.commitTransaction();
+
+                const finalOrder = await Order.findById(order._id).populate({
+                        path: "subOrders",
+                        populate: [
+                                {
+                                        path: "products.productId",
+                                        select: "title images price category",
+                                },
+                                {
+                                        path: "sellerId",
+                                        select: "name email businessName",
+                                },
+                        ],
+                });
+
+                return {
+                        order: finalOrder,
+                        orderId: finalOrder._id,
+                        orderNumber: finalOrder.orderNumber,
+                        subOrderIds,
+                };
+        } catch (error) {
+                await session.abortTransaction();
+                throw error;
+        } finally {
+                await session.endSession();
+        }
+}
+
+export default createOrderWithSubOrders;

--- a/lib/orders/email.js
+++ b/lib/orders/email.js
@@ -1,0 +1,309 @@
+import { companyInfo } from "@/constants/companyInfo.js";
+import { generateInvoicePDF } from "@/lib/invoicePDF.js";
+import { sendMail } from "@/lib/mail.js";
+
+const formatCurrency = (value) =>
+        `₹${Number(value || 0).toLocaleString("en-IN", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+        })}`;
+
+function toPlainOrder(order) {
+        if (order && typeof order.toObject === "function") {
+                return order.toObject();
+        }
+        return order || {};
+}
+
+function extractProducts(order) {
+        if (Array.isArray(order?.products) && order.products.length > 0) {
+                        return order.products.map((item) => ({
+                                productId: item.productId?._id || item.productId,
+                                productName:
+                                        item.productName ||
+                                        item.name ||
+                                        item.title ||
+                                        item.productId?.title ||
+                                        "Unknown Product",
+                                quantity: item.quantity || 0,
+                                price: Number(item.price ?? item.unitPrice ?? 0),
+                                totalPrice:
+                                        Number(
+                                                item.totalPrice ??
+                                                        Number(item.price ?? item.unitPrice ?? 0) *
+                                                                Number(item.quantity || 0)
+                                        ),
+                        }));
+        }
+
+        if (!Array.isArray(order?.subOrders)) {
+                return [];
+        }
+
+        return order.subOrders.flatMap((subOrder) => {
+                if (!Array.isArray(subOrder?.products)) {
+                        return [];
+                }
+
+                return subOrder.products.map((product) => ({
+                        productId: product.productId?._id || product.productId,
+                        productName:
+                                product.productName ||
+                                product.productId?.title ||
+                                product.productId?.name ||
+                                "Unknown Product",
+                        quantity: product.quantity || 0,
+                        price: Number(product.price ?? product.productId?.price ?? 0),
+                        totalPrice:
+                                Number(
+                                        product.totalPrice ??
+                                                Number(product.price ?? product.productId?.price ?? 0) *
+                                                        Number(product.quantity || 0)
+                                ),
+                }));
+        });
+}
+
+export function normalizeOrderForEmail(order) {
+        const plainOrder = toPlainOrder(order);
+        const products = extractProducts(plainOrder);
+
+        return {
+                ...plainOrder,
+                orderNumber: plainOrder.orderNumber,
+                orderDate: plainOrder.orderDate || plainOrder.createdAt || new Date(),
+                subtotal: Number(plainOrder.subtotal || 0),
+                tax: Number(plainOrder.tax || 0),
+                shippingCost: Number(plainOrder.shippingCost || 0),
+                discount: Number(plainOrder.discount || 0),
+                totalAmount: Number(plainOrder.totalAmount || 0),
+                customerName: plainOrder.customerName,
+                customerEmail: plainOrder.customerEmail,
+                customerMobile: plainOrder.customerMobile,
+                paymentMethod: plainOrder.paymentMethod,
+                paymentStatus: plainOrder.paymentStatus,
+                deliveryAddress:
+                        plainOrder.deliveryAddress ||
+                        plainOrder.shipToAddress ||
+                        plainOrder.billToAddress ||
+                        {},
+                products,
+        };
+}
+
+function buildOrderItemsHtml(products) {
+        if (!Array.isArray(products) || products.length === 0) {
+                return `<tr><td colspan="3" style="padding:8px;border:1px solid #e5e7eb;text-align:center;">No items found</td></tr>`;
+        }
+
+        return products
+                .map(
+                        (item) => `
+                                <tr>
+                                        <td style="padding:8px;border:1px solid #e5e7eb;">${item.productName}</td>
+                                        <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${
+                                                item.quantity
+                                        }</td>
+                                        <td style="padding:8px;border:1px solid #e5e7eb;text-align:right;">${formatCurrency(
+                                                item.totalPrice
+                                        )}</td>
+                                </tr>`
+                )
+                .join("");
+}
+
+function buildOrderSummaryHtml(order) {
+        const productsHtml = buildOrderItemsHtml(order.products);
+        const address = order.deliveryAddress || {};
+
+        return `
+                <h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Order Summary</h3>
+                <table style="width:100%;border-collapse:collapse;">
+                        <thead>
+                                <tr style="background:#f3f4f6;">
+                                        <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Product</th>
+                                        <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Qty</th>
+                                        <th style="padding:8px;border:1px solid #e5e7eb;text-align:right;">Total</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                ${productsHtml}
+                        </tbody>
+                </table>
+
+                <table style="width:100%;margin-top:8px;">
+                        <tr>
+                                <td style="text-align:right;padding:4px;">Subtotal:</td>
+                                <td style="text-align:right;padding:4px;">${formatCurrency(order.subtotal)}</td>
+                        </tr>
+                        ${order.tax > 0 ? `<tr><td style="text-align:right;padding:4px;">Tax:</td><td style="text-align:right;padding:4px;">${formatCurrency(order.tax)}</td></tr>` : ""}
+                        ${order.shippingCost > 0 ? `<tr><td style="text-align:right;padding:4px;">Shipping:</td><td style="text-align:right;padding:4px;">${formatCurrency(order.shippingCost)}</td></tr>` : ""}
+                        ${order.discount > 0 ? `<tr><td style="text-align:right;padding:4px;">Discount:</td><td style="text-align:right;padding:4px;">-${formatCurrency(order.discount)}</td></tr>` : ""}
+                        <tr>
+                                <td style="text-align:right;padding:4px;font-weight:bold;">Total:</td>
+                                <td style="text-align:right;padding:4px;font-weight:bold;">${formatCurrency(order.totalAmount)}</td>
+                        </tr>
+                </table>
+
+                <h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Shipping Address</h3>
+                <p style="margin:0;">${address.name || ""}</p>
+                <p style="margin:0;">${address.street || ""}</p>
+                <p style="margin:0;">${[address.city, address.state].filter(Boolean).join(", ")} ${
+                address.zipCode ? "- " + address.zipCode : ""
+        }</p>
+                <p style="margin:0;">${address.country || ""}</p>
+        `;
+}
+
+export async function sendOrderConfirmationEmail({
+        order,
+        to,
+        cc,
+        pdfBase64,
+        attachInvoice = false,
+} = {}) {
+        const normalizedOrder = normalizeOrderForEmail(order);
+
+        const recipients = Array.isArray(to)
+                ? to.filter(Boolean)
+                : to
+                ? [to]
+                : [];
+
+        if (recipients.length === 0 && normalizedOrder.customerEmail) {
+                recipients.push(normalizedOrder.customerEmail);
+        }
+
+        if (recipients.length === 0) {
+                throw new Error("No recipient email address available for confirmation email");
+        }
+
+        const formattedDate = new Date(normalizedOrder.orderDate).toLocaleDateString("en-IN", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+        });
+
+        const html = `
+                <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333;">
+                        <h2 style="color:#4f46e5;">Thank you for your order!</h2>
+                        <p>Hi ${normalizedOrder.customerName || "Customer"},</p>
+                        <p>Your order <strong>${normalizedOrder.orderNumber}</strong> has been placed successfully on ${formattedDate}.</p>
+
+                        ${buildOrderSummaryHtml(normalizedOrder)}
+
+                        <p style="margin-top:24px;">Your invoice is attached as a PDF for your records.</p>
+                        <p>If you have any questions, reply to this email or contact us at ${companyInfo.email}.</p>
+                        <p style="margin-top:16px;">Best regards,<br/>${
+                                companyInfo.name || companyInfo.companyName || "Team"
+                        }</p>
+                </div>
+        `;
+
+        const attachments = [];
+        let pdfError = null;
+
+        if (pdfBase64) {
+                try {
+                        const pdfBuffer = Buffer.from(pdfBase64, "base64");
+                        attachments.push({
+                                filename: `invoice-${normalizedOrder.orderNumber}.pdf`,
+                                content: pdfBuffer,
+                                contentType: "application/pdf",
+                        });
+                } catch (error) {
+                        pdfError = error.message;
+                }
+        } else if (attachInvoice) {
+                try {
+                        const invoiceBuffer = await generateInvoicePDF(normalizedOrder);
+                        if (invoiceBuffer) {
+                                attachments.push({
+                                        filename: `invoice-${normalizedOrder.orderNumber}.pdf`,
+                                        content: invoiceBuffer,
+                                        contentType: "application/pdf",
+                                });
+                        }
+                } catch (error) {
+                        pdfError = error.message;
+                }
+        }
+
+        await sendMail({
+                to: recipients,
+                cc,
+                subject: `Order Confirmed - ${normalizedOrder.orderNumber}`,
+                html,
+                attachments: attachments.length > 0 ? attachments : undefined,
+        });
+
+        return {
+                emailSent: true,
+                pdfAttached: attachments.length > 0,
+                pdfError,
+        };
+}
+
+export async function sendOrderFailureEmail({ order, to, cc, failureReason } = {}) {
+        const normalizedOrder = normalizeOrderForEmail(order);
+
+        const recipients = Array.isArray(to)
+                ? to.filter(Boolean)
+                : to
+                ? [to]
+                : [];
+
+        if (recipients.length === 0 && normalizedOrder.customerEmail) {
+                recipients.push(normalizedOrder.customerEmail);
+        }
+
+        if (recipients.length === 0) {
+                throw new Error("No recipient email address available for failure notification");
+        }
+
+        const productsHtml = buildOrderItemsHtml(normalizedOrder.products);
+
+        const html = `
+                <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333;">
+                        <h2 style="color:#dc2626;">We couldn't process your payment</h2>
+                        <p>Hi ${normalizedOrder.customerName || "Customer"},</p>
+                        <p>We attempted to process your payment for order <strong>${normalizedOrder.orderNumber || "(pending)"}</strong>, but it did not complete successfully.</p>
+                        ${failureReason ? `<p><strong>Reason:</strong> ${failureReason}</p>` : ""}
+
+                        <h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Items in your cart</h3>
+                        <table style="width:100%;border-collapse:collapse;">
+                                <thead>
+                                        <tr style="background:#f3f4f6;">
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Product</th>
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Qty</th>
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:right;">Total</th>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        ${productsHtml}
+                                </tbody>
+                        </table>
+
+                        <p style="margin-top:24px;">No payment has been captured for this order. You can try placing the order again from your cart.</p>
+                        <p>If you continue to face issues, please contact us at ${companyInfo.email}.</p>
+                        <p style="margin-top:16px;">Best regards,<br/>${
+                                companyInfo.name || companyInfo.companyName || "Team"
+                        }</p>
+                </div>
+        `;
+
+        await sendMail({
+                to: recipients,
+                cc,
+                subject: `Payment Failed - ${normalizedOrder.orderNumber || "Order Attempt"}`,
+                html,
+        });
+
+        return { emailSent: true };
+}
+
+export default {
+        normalizeOrderForEmail,
+        sendOrderConfirmationEmail,
+        sendOrderFailureEmail,
+};

--- a/model/Order.js
+++ b/model/Order.js
@@ -47,12 +47,20 @@ const OrderSchema = new mongoose.Schema(
 			],
 			required: true,
 		},
-		paymentStatus: {
-			type: String,
-			enum: ["pending", "paid", "failed", "refunded"],
-			default: "pending",
-		},
-		transactionId: String,
+                paymentStatus: {
+                        type: String,
+                        enum: ["pending", "paid", "failed", "refunded"],
+                        default: "pending",
+                },
+                transactionId: String,
+                paymentGatewayOrderId: {
+                        type: String,
+                        default: null,
+                },
+                paymentFailureReason: {
+                        type: String,
+                        default: null,
+                },
 
 		// Delivery Info (shared if same address)
 		deliveryAddress: {
@@ -99,5 +107,6 @@ OrderSchema.index({ userId: 1 });
 OrderSchema.index({ status: 1 });
 OrderSchema.index({ orderDate: -1 });
 OrderSchema.index({ customerEmail: 1 });
+OrderSchema.index({ paymentGatewayOrderId: 1 });
 
 export default mongoose.models.Order || mongoose.model("Order", OrderSchema);


### PR DESCRIPTION
## Summary
- add a shared order creation helper and refactor the order API to reuse it while importing the SubOrder model where necessary
- introduce reusable order email utilities and call them from payment verification and confirmation endpoints for reliable notifications
- harden the Razorpay integration by verifying signatures, recording failed attempts, adding a webhook handler, and updating the checkout flow to forward signature data

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68caa10635a8832ea33f06b2fbf55566