### PR TITLE
Add GST breakdown support across order workflows

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -39,6 +39,7 @@ import { useAuthStore, useLoggedInUser, useUserEmail } from "@/store/authStore";
 import { useProductStore } from "@/store/productStore.js";
 import { useCheckoutStore } from "@/store/checkoutStore.js";
 import Image from "next/image";
+import { buildGstLineItems } from "@/lib/utils/gst.js";
 
 export default function CheckoutPage() {
 	const router = useRouter();
@@ -765,12 +766,14 @@ export default function CheckoutPage() {
 		const currentCoupon =
 			checkoutType === "cart" ? cartAppliedCoupon : appliedCoupon;
 
-		return (
-			<Card className="sticky top-4">
-				<CardHeader>
-					<CardTitle>Order Summary</CardTitle>
-				</CardHeader>
-				<CardContent className="space-y-4">
+                const gstLines = buildGstLineItems(orderSummary.gst);
+
+                return (
+                        <Card className="sticky top-4">
+                                <CardHeader>
+                                        <CardTitle>Order Summary</CardTitle>
+                                </CardHeader>
+                                <CardContent className="space-y-4">
 					{/* Items */}
 					<div className="space-y-3">
 						{orderSummary.items.map((item, index) => (
@@ -876,18 +879,31 @@ export default function CheckoutPage() {
 								)}
 							</span>
 						</div>
-						{orderSummary.discount > 0 && (
-							<div className="flex justify-between text-green-600">
-								<span>Discount</span>
-								<span>-₹{orderSummary.discount.toLocaleString()}</span>
-							</div>
-						)}
-						<Separator />
-						<div className="flex justify-between font-bold text-lg">
-							<span>Total</span>
-							<span>₹{orderSummary.total.toLocaleString()}</span>
-						</div>
-					</div>
+                                                {orderSummary.discount > 0 && (
+                                                        <div className="flex justify-between text-green-600">
+                                                                <span>Discount</span>
+                                                                <span>-₹{orderSummary.discount.toLocaleString()}</span>
+                                                        </div>
+                                                )}
+                                                {gstLines.map((line) => (
+                                                        <div className="flex justify-between" key={line.key}>
+                                                                <span>{line.label}</span>
+                                                                <span>₹{line.amount.toLocaleString()}</span>
+                                                        </div>
+                                                ))}
+                                                <Separator />
+                                                <div className="flex justify-between font-bold text-lg">
+                                                        <span>Total</span>
+                                                        <span>₹{orderSummary.total.toLocaleString()}</span>
+                                                </div>
+                                                {gstLines.length > 0 && (
+                                                        <p className="text-xs text-gray-500">
+                                                                {orderSummary.gst?.mode === "cgst_sgst"
+                                                                        ? "CGST & SGST applied for Bengaluru deliveries"
+                                                                        : "IGST applied for this delivery"}
+                                                        </p>
+                                                )}
+                                        </div>
 
 					{/* Free shipping message */}
 					{orderSummary.subtotal < 500 && (

--- a/app/api/admin/orders/[id]/invoice/route.js
+++ b/app/api/admin/orders/[id]/invoice/route.js
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/lib/dbConnect.js";
 import Order from "@/model/Order.js";
-import Product from "@/model/Product.js";
 import { generateInvoicePDF } from "@/lib/generateInvoicePDF.js";
 
 export async function GET(request, { params }) {
@@ -28,11 +27,10 @@ export async function GET(request, { params }) {
 		}
 
 		// Aggregate all products from all subOrders
-		const allProducts = [];
-		let totalSubOrderAmount = 0;
+                const allProducts = [];
 
-		order.subOrders.forEach((subOrder) => {
-			subOrder.products.forEach((product) => {
+                order.subOrders.forEach((subOrder) => {
+                        subOrder.products.forEach((product) => {
 				allProducts.push({
 					productId: product.productId._id,
 					productName: product.productName || product.productId.title,
@@ -43,8 +41,7 @@ export async function GET(request, { params }) {
 					description: product.productId.description,
 				});
 			});
-			totalSubOrderAmount += subOrder.totalAmount || 0;
-		});
+                });
 
 		// Create order object for PDF generation
 		const orderForPDF = {
@@ -66,11 +63,13 @@ export async function GET(request, { params }) {
 			transactionId: order.transactionId,
 
 			// Pricing information
-			subtotal: order.subtotal,
-			tax: order.tax,
-			shippingCost: order.shippingCost,
-			discount: order.discount,
-			totalAmount: order.totalAmount,
+                        subtotal: order.subtotal,
+                        tax: order.tax,
+                        shippingCost: order.shippingCost,
+                        discount: order.discount,
+                        taxableAmount: order.taxableAmount,
+                        totalAmount: order.totalAmount,
+                        gst: order.gst,
 
 			// Coupon information
 			couponApplied: order.couponApplied,
@@ -89,11 +88,13 @@ export async function GET(request, { params }) {
 				trackingNumber: subOrder.trackingNumber,
 				estimatedDelivery: subOrder.estimatedDelivery,
 				actualDelivery: subOrder.actualDelivery,
-				subtotal: subOrder.subtotal,
-				tax: subOrder.tax,
-				shippingCost: subOrder.shippingCost,
-				discount: subOrder.discount,
-				totalAmount: subOrder.totalAmount,
+                                subtotal: subOrder.subtotal,
+                                tax: subOrder.tax,
+                                shippingCost: subOrder.shippingCost,
+                                discount: subOrder.discount,
+                                totalAmount: subOrder.totalAmount,
+                                taxableAmount: subOrder.taxableAmount,
+                                gst: subOrder.gst,
 				products: subOrder.products.map((product) => ({
 					productName: product.productName || product.productId.name,
 					quantity: product.quantity,

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -8,13 +8,17 @@ import { Badge } from "@/components/ui/badge";
 import { Download, Printer } from "lucide-react";
 import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 import { toast } from "sonner";
+import { buildGstLineItems } from "@/lib/utils/gst.js";
 
 export function InvoicePopup({ open, onOpenChange, order }) {
 	const { downloadInvoice } = useAdminOrderStore();
 
-	if (!order) return null;
+        if (!order) return null;
 
-	const handleDownload = async () => {
+        const gstLines = buildGstLineItems(order.gst);
+        const gstMode = order?.gst?.mode || "igst";
+
+        const handleDownload = async () => {
 		const result = await downloadInvoice(order._id, order.orderNumber);
 		if (result.success) {
 			toast.success("Invoice downloaded successfully");
@@ -183,17 +187,17 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 							<span>Subtotal</span>
 							<span>${order.subtotal.toFixed(2)}</span>
 						</div>
-						{order.tax > 0 && (
-							<div className="flex justify-between">
-								<span>Tax</span>
-								<span>${order.tax.toFixed(2)}</span>
-							</div>
-						)}
-						{order.shippingCost > 0 && (
-							<div className="flex justify-between">
-								<span>Shipping</span>
-								<span>${order.shippingCost.toFixed(2)}</span>
-							</div>
+                                                {gstLines.map((line) => (
+                                                        <div className="flex justify-between" key={line.key}>
+                                                                <span>{line.label}</span>
+                                                                <span>${line.amount.toFixed(2)}</span>
+                                                        </div>
+                                                ))}
+                                                {order.shippingCost > 0 && (
+                                                        <div className="flex justify-between">
+                                                                <span>Shipping</span>
+                                                                <span>${order.shippingCost.toFixed(2)}</span>
+                                                        </div>
 						)}
 						{order.discount > 0 && (
 							<div className="flex justify-between text-green-600">
@@ -207,12 +211,19 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 								<span>-${order.couponApplied.discountAmount.toFixed(2)}</span>
 							</div>
 						)}
-						<Separator />
-						<div className="flex justify-between font-bold text-lg">
-							<span>Total Amount</span>
-							<span>${order.totalAmount.toFixed(2)}</span>
-						</div>
-					</div>
+                                                <Separator />
+                                                <div className="flex justify-between font-bold text-lg">
+                                                        <span>Total Amount</span>
+                                                        <span>${order.totalAmount.toFixed(2)}</span>
+                                                </div>
+                                                {gstLines.length > 0 && (
+                                                        <p className="text-xs text-gray-500">
+                                                                {gstMode === "cgst_sgst"
+                                                                        ? "CGST & SGST applied for Bengaluru deliveries"
+                                                                        : "IGST applied for this delivery"}
+                                                        </p>
+                                                )}
+                                        </div>
 
 					<Separator />
 

--- a/components/AdminPanel/Popups/OrderDetailsPopup.jsx
+++ b/components/AdminPanel/Popups/OrderDetailsPopup.jsx
@@ -11,21 +11,25 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-	Package,
-	User,
-	MapPin,
-	CreditCard,
-	Calendar,
-	Phone,
-	Mail,
-	Truck,
+        Package,
+        User,
+        MapPin,
+        CreditCard,
+        Calendar,
+        Phone,
+        Mail,
+        Truck,
 } from "lucide-react";
+import { buildGstLineItems } from "@/lib/utils/gst.js";
 
 export function OrderDetailsPopup({ open, onOpenChange, order }) {
-	if (!order) return null;
+        if (!order) return null;
 
-	const getStatusColor = (status) => {
-		const colors = {
+        const gstLines = buildGstLineItems(order.gst);
+        const gstMode = order?.gst?.mode || "igst";
+
+        const getStatusColor = (status) => {
+                const colors = {
 			pending: "bg-yellow-100 text-yellow-800",
 			confirmed: "bg-blue-100 text-blue-800",
 			processing: "bg-purple-100 text-purple-800",
@@ -37,7 +41,7 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 		return colors[status] || "bg-gray-100 text-gray-800";
 	};
 
-	const getPaymentStatusColor = (status) => {
+        const getPaymentStatusColor = (status) => {
 		const colors = {
 			paid: "bg-green-100 text-green-800",
 			pending: "bg-yellow-100 text-yellow-800",
@@ -247,17 +251,17 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 										<span>Subtotal</span>
 										<span>${order.subtotal.toFixed(2)}</span>
 									</div>
-									{order.tax > 0 && (
-										<div className="flex justify-between">
-											<span>Tax</span>
-											<span>${order.tax.toFixed(2)}</span>
-										</div>
-									)}
-									{order.shippingCost > 0 && (
-										<div className="flex justify-between">
-											<span>Shipping</span>
-											<span>${order.shippingCost.toFixed(2)}</span>
-										</div>
+                                                                        {gstLines.map((line) => (
+                                                                                <div className="flex justify-between" key={line.key}>
+                                                                                        <span>{line.label}</span>
+                                                                                        <span>${line.amount.toFixed(2)}</span>
+                                                                                </div>
+                                                                        ))}
+                                                                        {order.shippingCost > 0 && (
+                                                                                <div className="flex justify-between">
+                                                                                        <span>Shipping</span>
+                                                                                        <span>${order.shippingCost.toFixed(2)}</span>
+                                                                                </div>
 									)}
 									{order.discount > 0 && (
 										<div className="flex justify-between text-green-600">
@@ -273,14 +277,21 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 											</span>
 										</div>
 									)}
-									<Separator />
-									<div className="flex justify-between text-lg font-bold">
-										<span>Total Amount</span>
-										<span>${order.totalAmount.toFixed(2)}</span>
-									</div>
-								</div>
-							</CardContent>
-						</Card>
+                                                                        <Separator />
+                                                                        <div className="flex justify-between text-lg font-bold">
+                                                                                <span>Total Amount</span>
+                                                                                <span>${order.totalAmount.toFixed(2)}</span>
+                                                                        </div>
+                                                                        {gstLines.length > 0 && (
+                                                                                <p className="text-xs text-gray-500">
+                                                                                        {gstMode === "cgst_sgst"
+                                                                                                ? "CGST & SGST applied for Bengaluru deliveries"
+                                                                                                : "IGST applied for this delivery"}
+                                                                                </p>
+                                                                        )}
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
 
 						{/* Tracking Information */}
 						{order.trackingNumber && (

--- a/components/BuyerPanel/account/tabs/SubComponents/OrderDetailPopup.jsx
+++ b/components/BuyerPanel/account/tabs/SubComponents/OrderDetailPopup.jsx
@@ -21,6 +21,7 @@ import {
 	Truck,
 } from "lucide-react";
 import Image from "next/image";
+import { buildGstLineItems } from "@/lib/utils/gst.js";
 
 export function OrderDetailPopup({ open, onOpenChange, order }) {
 	if (!order) return null;
@@ -66,10 +67,11 @@ export function OrderDetailPopup({ open, onOpenChange, order }) {
 	const paymentMethod = order.paymentMethod || "N/A";
 	const transactionId = order.transactionId || null;
 	const subtotal = order.subtotal || 0;
-	const tax = order.tax || 0;
-	const shippingCost = order.shippingCost || order.shipping || 0;
-	const discount = order.discount || 0;
-	const totalAmount = order.totalAmount || order.total || 0;
+        const gstLines = buildGstLineItems(order.gst);
+        const gstMode = order?.gst?.mode || "igst";
+        const shippingCost = order.shippingCost || order.shipping || 0;
+        const discount = order.discount || 0;
+        const totalAmount = order.totalAmount || order.total || 0;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -317,17 +319,17 @@ export function OrderDetailPopup({ open, onOpenChange, order }) {
 										<span>Subtotal</span>
 										<span>₹{subtotal.toFixed(2)}</span>
 									</div>
-									{tax > 0 && (
-										<div className="flex justify-between">
-											<span>Tax</span>
-											<span>₹{tax.toFixed(2)}</span>
-										</div>
-									)}
-									{shippingCost > 0 && (
-										<div className="flex justify-between">
-											<span>Shipping</span>
-											<span>₹{shippingCost.toFixed(2)}</span>
-										</div>
+                                                                        {gstLines.map((line) => (
+                                                                                <div className="flex justify-between" key={line.key}>
+                                                                                        <span>{line.label}</span>
+                                                                                        <span>₹{line.amount.toFixed(2)}</span>
+                                                                                </div>
+                                                                        ))}
+                                                                        {shippingCost > 0 && (
+                                                                                <div className="flex justify-between">
+                                                                                        <span>Shipping</span>
+                                                                                        <span>₹{shippingCost.toFixed(2)}</span>
+                                                                                </div>
 									)}
 									{discount > 0 && (
 										<div className="flex justify-between text-green-600">
@@ -343,14 +345,21 @@ export function OrderDetailPopup({ open, onOpenChange, order }) {
 											</span>
 										</div>
 									)}
-									<Separator />
-									<div className="flex justify-between text-lg font-bold">
-										<span>Total Amount</span>
-										<span>₹{totalAmount.toFixed(2)}</span>
-									</div>
-								</div>
-							</CardContent>
-						</Card>
+                                                                        <Separator />
+                                                                        <div className="flex justify-between text-lg font-bold">
+                                                                                <span>Total Amount</span>
+                                                                                <span>₹{totalAmount.toFixed(2)}</span>
+                                                                        </div>
+                                                                        {gstLines.length > 0 && (
+                                                                                <p className="text-xs text-gray-500">
+                                                                                        {gstMode === "cgst_sgst"
+                                                                                                ? "CGST & SGST applied for Bengaluru deliveries"
+                                                                                                : "IGST applied for this delivery"}
+                                                                                </p>
+                                                                        )}
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
 
 						{/* Tracking Information */}
 						{order.trackingNumber && (

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -1,12 +1,48 @@
 import jsPDF from "jspdf";
+import { buildGstLineItems, GST_RATE_PERCENT } from "@/lib/utils/gst.js";
 
 export const generateInvoicePDF = async (order) => {
-	try {
-		// Create new jsPDF instance
-		const doc = new jsPDF();
+        try {
+                // Create new jsPDF instance
+                const doc = new jsPDF();
 
-		// Set font
-		doc.setFont("helvetica");
+                const sanitizeNumber = (value) => {
+                        const numeric = Number(value);
+                        return Number.isFinite(numeric) ? numeric : 0;
+                };
+
+                const formatAmount = (value) => sanitizeNumber(value).toFixed(2);
+                const formatRate = (value) => {
+                        const numeric = Number(value);
+                        if (!Number.isFinite(numeric)) {
+                                return "0";
+                        }
+                        const fixed = numeric.toFixed(2);
+                        return fixed.replace(/\.00$/, "").replace(/(\.[0-9]*[1-9])0+$/, "$1");
+                };
+
+                const gstMode = order?.gst?.mode || "igst";
+                const gstRate = Number.isFinite(Number(order?.gst?.rate))
+                        ? Number(order.gst.rate)
+                        : GST_RATE_PERCENT;
+                const cgstRate = gstMode === "cgst_sgst" ? gstRate / 2 : 0;
+                const sgstRate = gstMode === "cgst_sgst" ? gstRate / 2 : 0;
+                const igstRate = gstMode === "igst" ? gstRate : 0;
+                const gstLineItems = buildGstLineItems(order?.gst);
+                const gstLineLookup = gstLineItems.reduce((acc, item) => {
+                        acc[item.key] = item.label;
+                        return acc;
+                }, {});
+
+                const cgstTotal = sanitizeNumber(order?.gst?.cgst);
+                const sgstTotal = sanitizeNumber(order?.gst?.sgst);
+                const igstTotal = sanitizeNumber(order?.gst?.igst);
+                const taxableBase = sanitizeNumber(
+                        order?.gst?.taxableAmount ?? order?.taxableAmount ?? order?.subtotal
+                );
+
+                // Set font
+                doc.setFont("helvetica");
 
 		// Company Header
 		doc.setFontSize(24);
@@ -81,7 +117,7 @@ export const generateInvoicePDF = async (order) => {
 		// Total Amount (Large)
 		doc.setFontSize(18);
 		doc.setTextColor(249, 115, 22);
-		doc.text(`${(order.totalAmount || 0).toFixed(2)}`, 150, 125);
+                doc.text(`${formatAmount(order.totalAmount || 0)}`, 150, 125);
 
 		// Payment Information
 		doc.setFontSize(10);
@@ -116,42 +152,89 @@ export const generateInvoicePDF = async (order) => {
 
 		yPosition += 15;
 
-		// Products
-		if (order.products && order.products.length > 0) {
-			order.products.forEach((product, index) => {
-				if (yPosition > 250) {
-					doc.addPage();
-					yPosition = 30;
-				}
+                // Products
+                if (order.products && order.products.length > 0) {
+                        order.products.forEach((product) => {
+                                if (yPosition > 250) {
+                                        doc.addPage();
+                                        yPosition = 30;
+                                }
 
-				doc.setFontSize(10);
-				doc.setTextColor(0, 0, 0);
+                                doc.setFontSize(10);
+                                doc.setTextColor(0, 0, 0);
 
-				// Truncate long product names
-				const productName = product.productName.substring(0, 30);
-				doc.text(productName, 25, yPosition);
-				doc.text((product.quantity || 0).toString(), 100, yPosition);
-				doc.text(`${(product.price || 0).toFixed(2)}`, 125, yPosition);
-				doc.text(`${(product.totalPrice || 0).toFixed(2)}`, 160, yPosition);
+                                const productName = (product.productName || "Item").substring(0, 30);
+                                const quantity = sanitizeNumber(product.quantity);
+                                const unitPrice = sanitizeNumber(product.price);
+                                const productTotal = sanitizeNumber(
+                                        product.totalPrice || unitPrice * quantity
+                                );
 
-				if (product.productId) {
-					doc.setFontSize(8);
-					doc.setTextColor(102, 102, 102);
-					doc.text(
-						`ID: ${product.productId.toString().substring(0, 10)}...`,
-						25,
-						yPosition + 4
-					);
-				}
+                                const share = taxableBase > 0 ? productTotal / taxableBase : 0;
+                                const productCgst = share * cgstTotal;
+                                const productSgst = share * sgstTotal;
+                                const productIgst = share * igstTotal;
 
-				yPosition += 12;
+                                const taxLines = [];
+                                if (gstMode === "igst" && productIgst > 0) {
+                                        const label =
+                                                gstLineLookup.igst ||
+                                                `IGST (${formatRate(igstRate)}%)`;
+                                        taxLines.push(`${label}: ₹${formatAmount(productIgst)}`);
+                                } else if (gstMode === "cgst_sgst") {
+                                        if (productCgst > 0) {
+                                                const label =
+                                                        gstLineLookup.cgst ||
+                                                        `CGST (${formatRate(cgstRate)}%)`;
+                                                taxLines.push(`${label}: ₹${formatAmount(productCgst)}`);
+                                        }
+                                        if (productSgst > 0) {
+                                                const label =
+                                                        gstLineLookup.sgst ||
+                                                        `SGST (${formatRate(sgstRate)}%)`;
+                                                taxLines.push(`${label}: ₹${formatAmount(productSgst)}`);
+                                        }
+                                }
 
-				// Line separator
-				doc.setDrawColor(229, 229, 229);
-				doc.line(20, yPosition, 190, yPosition);
-				yPosition += 5;
-			});
-		}
+                                doc.text(productName, 25, yPosition);
+                                doc.text(quantity.toString(), 100, yPosition);
+                                doc.text(`${formatAmount(unitPrice)}`, 125, yPosition);
+                                doc.text(`${formatAmount(productTotal)}`, 160, yPosition);
+
+                                const detailLines = [];
+                                if (product.productId) {
+                                        detailLines.push({
+                                                text: `ID: ${product.productId
+                                                        .toString()
+                                                        .substring(0, 10)}...`,
+                                                x: 25,
+                                        });
+                                }
+                                taxLines.forEach((line) => {
+                                        detailLines.push({ text: line, x: 125 });
+                                });
+
+                                if (detailLines.length > 0) {
+                                        doc.setFontSize(8);
+                                        doc.setTextColor(102, 102, 102);
+                                        let offset = 4;
+                                        detailLines.forEach((detail) => {
+                                                doc.text(detail.text, detail.x, yPosition + offset);
+                                                offset += 4;
+                                        });
+                                        doc.setFontSize(10);
+                                        doc.setTextColor(0, 0, 0);
+                                        yPosition += offset - 4;
+                                }
+
+                                yPosition += 12;
+
+                                // Line separator
+                                doc.setDrawColor(229, 229, 229);
+                                doc.line(20, yPosition, 190, yPosition);
+                                yPosition += 5;
+                        });
+                }
 
 		// Totals Section
 		yPosition += 10;
@@ -159,26 +242,30 @@ export const generateInvoicePDF = async (order) => {
 		doc.setFontSize(10);
 		doc.setTextColor(0, 0, 0);
 		doc.text("Subtotal:", 150, yPosition);
-		doc.text(`${(order.subtotal || 0).toFixed(2)}`, 175, yPosition);
+                doc.text(`${formatAmount(order.subtotal || 0)}`, 175, yPosition);
 
-		if (order.tax && order.tax > 0) {
-			yPosition += 8;
-			doc.text("Tax:", 150, yPosition);
-			doc.text(`${order.tax.toFixed(2)}`, 175, yPosition);
-		}
+                if (gstLineItems.length > 0) {
+                        gstLineItems.forEach((line) => {
+                                yPosition += 8;
+                                doc.setTextColor(0, 0, 0);
+                                doc.text(line.label, 150, yPosition);
+                                doc.text(`${formatAmount(line.amount)}`, 175, yPosition);
+                        });
+                }
 
-		if (order.shippingCost && order.shippingCost > 0) {
-			yPosition += 8;
-			doc.text("Shipping:", 150, yPosition);
-			doc.text(`${order.shippingCost.toFixed(2)}`, 175, yPosition);
-		}
+                if (order.shippingCost && order.shippingCost > 0) {
+                        yPosition += 8;
+                        doc.text("Shipping:", 150, yPosition);
+                        doc.text(`${formatAmount(order.shippingCost)}`, 175, yPosition);
+                }
 
-		if (order.discount && order.discount > 0) {
-			yPosition += 8;
-			doc.setTextColor(16, 185, 129); // Green color
-			doc.text("Discount:", 150, yPosition);
-			doc.text(`-${order.discount.toFixed(2)}`, 175, yPosition);
-		}
+                if (order.discount && order.discount > 0) {
+                        yPosition += 8;
+                        doc.setTextColor(16, 185, 129); // Green color
+                        doc.text("Discount:", 150, yPosition);
+                        doc.text(`-${formatAmount(order.discount)}`, 175, yPosition);
+                        doc.setTextColor(0, 0, 0);
+                }
 
 		if (order.couponApplied && order.couponApplied.discountAmount > 0) {
 			yPosition += 8;
@@ -201,7 +288,7 @@ export const generateInvoicePDF = async (order) => {
 		doc.setFontSize(12);
 		doc.setTextColor(0, 0, 0);
 		doc.text("Total Amount:-  ", 150, yPosition);
-		doc.text(`  ${(order.totalAmount || 0).toFixed(2)}`, 175, yPosition);
+                doc.text(`  ${formatAmount(order.totalAmount || 0)}`, 175, yPosition);
 
 		// Footer
 		yPosition += 20;

--- a/lib/invoicePDF.js
+++ b/lib/invoicePDF.js
@@ -9,6 +9,7 @@ import {
 	Font,
 } from "@react-pdf/renderer";
 import { companyInfo } from "@/constants/companyInfo.js";
+import { buildGstLineItems, GST_RATE_PERCENT } from "@/lib/utils/gst.js";
 
 // Register a font with the Indian Rupee symbol (₹) using a CDN that
 // supports query strings so React PDF can request only the glyphs it needs.
@@ -314,15 +315,35 @@ const InvoiceDocument = ({ order }) => {
 			? `${companyInfo.website}${companyInfo.logo}`
 			: companyInfo.logo;
 
-	const cgstRate = order.subtotal
-		? (order.gst?.cgst / order.subtotal) * 100
-		: 0;
-	const sgstRate = order.subtotal
-		? (order.gst?.sgst / order.subtotal) * 100
-		: 0;
-	const igstRate = order.subtotal
-		? (order.gst?.igst / order.subtotal) * 100
-		: 0;
+        const formatRateValue = (value) => {
+                const numeric = Number(value);
+                if (!Number.isFinite(numeric)) {
+                        return "0";
+                }
+                if (Number.isInteger(numeric)) {
+                        return numeric.toString();
+                }
+                return numeric.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+        };
+
+        const gstMode = order?.gst?.mode || "igst";
+        const gstRate = Number.isFinite(Number(order?.gst?.rate))
+                ? Number(order.gst.rate)
+                : GST_RATE_PERCENT;
+        const cgstRate = gstMode === "cgst_sgst" ? gstRate / 2 : 0;
+        const sgstRate = gstMode === "cgst_sgst" ? gstRate / 2 : 0;
+        const igstRate = gstMode === "igst" ? gstRate : 0;
+        const cgstTotal = Number(order?.gst?.cgst || 0);
+        const sgstTotal = Number(order?.gst?.sgst || 0);
+        const igstTotal = Number(order?.gst?.igst || 0);
+        const taxableBase = Number(
+                order?.gst?.taxableAmount ?? order?.taxableAmount ?? Math.max((order?.subtotal || 0) - (order?.discount || 0), 0)
+        );
+        const gstLineItems = buildGstLineItems(order.gst);
+        const gstLineLookup = gstLineItems.reduce((acc, line) => {
+                acc[line.key] = line.label;
+                return acc;
+        }, {});
 
         const orderDate = order?.orderDate ? new Date(order.orderDate) : null;
         const dueDate = order?.paymentDueDate
@@ -344,26 +365,10 @@ const InvoiceDocument = ({ order }) => {
                           : 0;
         const balanceDue = Math.max((order?.totalAmount || 0) - amountPaid, 0);
 
-        const totalTaxLines = [];
-        if (order.gst?.igst > 0) {
-                totalTaxLines.push({
-                        label: `IGST ${igstRate.toFixed(0)}%`,
-                        amount: order.gst.igst,
-                });
-	} else {
-		if (order.gst?.cgst > 0) {
-			totalTaxLines.push({
-				label: `CGST ${cgstRate.toFixed(0)}%`,
-				amount: order.gst.cgst,
-			});
-		}
-		if (order.gst?.sgst > 0) {
-			totalTaxLines.push({
-				label: `SGST ${sgstRate.toFixed(0)}%`,
-				amount: order.gst.sgst,
-			});
-		}
-	}
+        const totalTaxLines = gstLineItems.map((line) => ({
+                label: line.label,
+                amount: line.amount,
+        }));
 
         const products = Array.isArray(order?.products) ? order.products : [];
         const billingAddress = order?.billToAddress || null;
@@ -528,47 +533,52 @@ const InvoiceDocument = ({ order }) => {
                                                 </View>
                                         </View>
                                         {products.map((product, index) => {
-                                                const cgstTotal = order.gst?.cgst || 0;
-                                                const sgstTotal = order.gst?.sgst || 0;
-                                                const igstTotal = order.gst?.igst || 0;
-
-                                                const quantity =
-                                                        typeof product.quantity === "number"
-                                                                ? product.quantity
-                                                                : Number(product.quantity) || 0;
-                                                const unitPrice =
-                                                        typeof product.price === "number"
-                                                                ? product.price
-                                                                : Number(product.price) || 0;
-                                                const productTotal =
-                                                        typeof product.totalPrice === "number"
-                                                                ? product.totalPrice
-                                                                : unitPrice * quantity;
+                                                const quantity = Number.isFinite(Number(product.quantity))
+                                                        ? Number(product.quantity)
+                                                        : 0;
+                                                const unitPrice = Number.isFinite(Number(product.price))
+                                                        ? Number(product.price)
+                                                        : 0;
+                                                const productTotal = Number.isFinite(Number(product.totalPrice))
+                                                        ? Number(product.totalPrice)
+                                                        : unitPrice * quantity;
 
                                                 const productName = product.productName || product.name || product.title || "Item";
                                                 const displayQuantity = Number.isFinite(quantity) ? quantity : "-";
 
-                                                const productCgst =
-                                                        order.subtotal > 0
-                                                                ? (productTotal / order.subtotal) * cgstTotal
-                                                                : 0;
-                                                const productSgst =
-                                                        order.subtotal > 0
-                                                                ? (productTotal / order.subtotal) * sgstTotal
-                                                                : 0;
-                                                const productIgst =
-                                                        order.subtotal > 0
-                                                                ? (productTotal / order.subtotal) * igstTotal
-                                                                : 0;
+                                                const share = taxableBase > 0 ? productTotal / taxableBase : 0;
+                                                const productCgst = share * cgstTotal;
+                                                const productSgst = share * sgstTotal;
+                                                const productIgst = share * igstTotal;
 
                                                 let taxType = "-";
                                                 let taxAmountStr = "-";
-                                                if (igstTotal > 0) {
-                                                        taxType = `IGST ${igstRate.toFixed(0)}%`;
+                                                if (gstMode === "igst" && productIgst > 0) {
+                                                        taxType =
+                                                                gstLineLookup.igst ||
+                                                                `IGST (${formatRateValue(igstRate)}%)`;
                                                         taxAmountStr = formatCurrency(productIgst);
-                                                } else if (cgstTotal > 0 || sgstTotal > 0) {
-                                                        taxType = `CGST ${cgstRate.toFixed(0)}%\nSGST ${sgstRate.toFixed(0)}%`;
-                                                        taxAmountStr = `${formatCurrency(productCgst)}\n${formatCurrency(productSgst)}`;
+                                                } else if (gstMode === "cgst_sgst") {
+                                                        const taxTypeParts = [];
+                                                        const taxAmountParts = [];
+                                                        if (productCgst > 0) {
+                                                                taxTypeParts.push(
+                                                                        gstLineLookup.cgst ||
+                                                                                `CGST (${formatRateValue(cgstRate)}%)`
+                                                                );
+                                                                taxAmountParts.push(formatCurrency(productCgst));
+                                                        }
+                                                        if (productSgst > 0) {
+                                                                taxTypeParts.push(
+                                                                        gstLineLookup.sgst ||
+                                                                                `SGST (${formatRateValue(sgstRate)}%)`
+                                                                );
+                                                                taxAmountParts.push(formatCurrency(productSgst));
+                                                        }
+                                                        if (taxTypeParts.length > 0) {
+                                                                taxType = taxTypeParts.join("\n");
+                                                                taxAmountStr = taxAmountParts.join("\n");
+                                                        }
                                                 }
 
                                                 const productTax = productCgst + productSgst + productIgst;

--- a/lib/orders/createOrder.js
+++ b/lib/orders/createOrder.js
@@ -4,21 +4,31 @@ import Order from "@/model/Order.js";
 import SubOrder from "@/model/SubOrder.js";
 import Product from "@/model/Product.js";
 import Cart from "@/model/Cart.js";
+import { calculateGstTotals, determineGstMode, GST_RATE_PERCENT } from "@/lib/utils/gst.js";
 
-function calculateTotals(items, discountPercentage = 0) {
+function calculateTotals(items, { discountPercentage = 0, gstMode = "igst", gstRatePercent = GST_RATE_PERCENT } = {}) {
         const subtotal = items.reduce((sum, item) => sum + (item.totalPrice || 0), 0);
-        const discount = (subtotal * discountPercentage) / 100;
-        const discountedSubtotal = subtotal - discount;
-        const tax = discountedSubtotal * 0.18;
+        const discountAmount = (subtotal * discountPercentage) / 100;
+        const discountedSubtotal = subtotal - discountAmount;
         const shippingCost = discountedSubtotal >= 500 ? 0 : 50;
-        const totalAmount = discountedSubtotal + tax + shippingCost;
+
+        const totals = calculateGstTotals({
+                subtotal,
+                discount: discountAmount,
+                shippingCost,
+                gstMode,
+                gstRatePercent,
+        });
 
         return {
-                subtotal,
-                tax: Math.round(tax * 100) / 100,
-                shippingCost,
-                discount: Math.round(discount * 100) / 100,
-                totalAmount: Math.round(totalAmount * 100) / 100,
+                subtotal: totals.subtotal,
+                discount: totals.discount,
+                shippingCost: totals.shippingCost,
+                total: totals.total,
+                totalAmount: totals.total,
+                tax: totals.gst.total,
+                gst: totals.gst,
+                taxableAmount: totals.taxableAmount,
         };
 }
 
@@ -67,6 +77,21 @@ export async function createOrderWithSubOrders({
                 const paymentFailureReason =
                         paymentInfo.paymentFailureReason || orderData.paymentFailureReason || null;
 
+                const subtotalValue = normalizeNumber(orderData.subtotal);
+                const discountValue = normalizeNumber(orderData.discount);
+                const shippingCostValue = normalizeNumber(orderData.shippingCost);
+                const gstRate = orderData?.gst?.rate ?? GST_RATE_PERCENT;
+                const gstMode = orderData?.gst?.mode || determineGstMode(orderData.deliveryAddress);
+
+                const totals = calculateGstTotals({
+                        subtotal: subtotalValue,
+                        discount: discountValue,
+                        shippingCost: shippingCostValue,
+                        address: orderData.deliveryAddress,
+                        gstMode,
+                        gstRatePercent: gstRate,
+                });
+
                 const orderPayload = {
                         orderNumber:
                                 orderData.orderNumber ||
@@ -75,11 +100,13 @@ export async function createOrderWithSubOrders({
                         customerName: orderData.customerName,
                         customerEmail: orderData.customerEmail,
                         customerMobile: orderData.customerMobile,
-                        subtotal: normalizeNumber(orderData.subtotal),
-                        tax: normalizeNumber(orderData.tax),
-                        shippingCost: normalizeNumber(orderData.shippingCost),
-                        discount: normalizeNumber(orderData.discount),
-                        totalAmount: normalizeNumber(orderData.totalAmount),
+                        subtotal: totals.subtotal,
+                        tax: totals.gst.total,
+                        shippingCost: totals.shippingCost,
+                        discount: totals.discount,
+                        totalAmount: totals.total,
+                        gst: totals.gst,
+                        taxableAmount: totals.taxableAmount,
                         couponApplied: orderData.couponApplied || null,
                         paymentMethod: orderData.paymentMethod,
                         paymentStatus: effectivePaymentStatus,
@@ -155,7 +182,10 @@ export async function createOrderWithSubOrders({
                 const subOrderPayloads = [];
 
                 for (const [sellerKey, items] of productsBySeller.entries()) {
-                        const totals = calculateTotals(items);
+                        const totals = calculateTotals(items, {
+                                gstMode,
+                                gstRatePercent: gstRate,
+                        });
 
                         const sellerObjectId = mongoose.Types.ObjectId.isValid(sellerKey)
                                 ? new mongoose.Types.ObjectId(sellerKey)
@@ -172,11 +202,13 @@ export async function createOrderWithSubOrders({
                                         price: normalizeNumber(item.price),
                                         totalPrice: normalizeNumber(item.totalPrice),
                                 })),
-                                subtotal: totals.subtotal,
-                                tax: totals.tax,
-                                shippingCost: totals.shippingCost,
-                                discount: totals.discount,
-                                totalAmount: totals.totalAmount,
+                        subtotal: totals.subtotal,
+                        tax: totals.tax,
+                        shippingCost: totals.shippingCost,
+                        discount: totals.discount,
+                        totalAmount: totals.total,
+                        gst: totals.gst,
+                        taxableAmount: totals.taxableAmount,
                                 couponApplied: orderData.couponApplied || null,
                                 status: effectiveSubOrderStatus,
                         });

--- a/lib/orders/email.js
+++ b/lib/orders/email.js
@@ -1,6 +1,7 @@
 import { companyInfo } from "@/constants/companyInfo.js";
 import { generateInvoicePDF } from "@/lib/invoicePDF.js";
 import { sendMail } from "@/lib/mail.js";
+import { buildGstLineItems, calculateGstTotals, determineGstMode, GST_RATE_PERCENT } from "@/lib/utils/gst.js";
 
 const formatCurrency = (value) =>
         `₹${Number(value || 0).toLocaleString("en-IN", {
@@ -68,15 +69,61 @@ export function normalizeOrderForEmail(order) {
         const plainOrder = toPlainOrder(order);
         const products = extractProducts(plainOrder);
 
+        const sanitizeAmount = (value, fallback = 0) => {
+                const numeric = Number(value);
+                return Number.isFinite(numeric) ? numeric : fallback;
+        };
+
+        const subtotalValue = sanitizeAmount(plainOrder.subtotal);
+        const discountValue = sanitizeAmount(plainOrder.discount);
+        const shippingCostValue = sanitizeAmount(plainOrder.shippingCost);
+        const address = plainOrder.deliveryAddress || {};
+        const existingGst =
+                plainOrder && typeof plainOrder.gst === "object" ? plainOrder.gst : {};
+
+        const gstMode = existingGst.mode || determineGstMode(address);
+        const gstRate = Number.isFinite(Number(existingGst.rate))
+                ? Number(existingGst.rate)
+                : GST_RATE_PERCENT;
+
+        const totals = calculateGstTotals({
+                subtotal: subtotalValue,
+                discount: discountValue,
+                shippingCost: shippingCostValue,
+                address,
+                gstMode,
+                gstRatePercent: gstRate,
+        });
+
+        const sanitizedGst = {
+                mode: gstMode,
+                rate: gstRate,
+                cgst: sanitizeAmount(existingGst.cgst, totals.gst.cgst),
+                sgst: sanitizeAmount(existingGst.sgst, totals.gst.sgst),
+                igst: sanitizeAmount(existingGst.igst, totals.gst.igst),
+                total: sanitizeAmount(existingGst.total, totals.gst.total),
+                taxableAmount: sanitizeAmount(
+                        existingGst.taxableAmount,
+                        totals.gst.taxableAmount
+                ),
+        };
+
+        if (!sanitizedGst.total) {
+                const summed = sanitizedGst.cgst + sanitizedGst.sgst + sanitizedGst.igst;
+                sanitizedGst.total = sanitizeAmount(summed, totals.gst.total);
+        }
+
         return {
                 ...plainOrder,
                 orderNumber: plainOrder.orderNumber,
                 orderDate: plainOrder.orderDate || plainOrder.createdAt || new Date(),
-                subtotal: Number(plainOrder.subtotal || 0),
-                tax: Number(plainOrder.tax || 0),
-                shippingCost: Number(plainOrder.shippingCost || 0),
-                discount: Number(plainOrder.discount || 0),
-                totalAmount: Number(plainOrder.totalAmount || 0),
+                subtotal: totals.subtotal,
+                tax: sanitizedGst.total,
+                shippingCost: totals.shippingCost,
+                discount: totals.discount,
+                totalAmount: sanitizeAmount(plainOrder.totalAmount, totals.total),
+                gst: sanitizedGst,
+                taxableAmount: sanitizedGst.taxableAmount,
                 customerName: plainOrder.customerName,
                 customerEmail: plainOrder.customerEmail,
                 customerMobile: plainOrder.customerMobile,
@@ -115,6 +162,26 @@ function buildOrderItemsHtml(products) {
 function buildOrderSummaryHtml(order) {
         const productsHtml = buildOrderItemsHtml(order.products);
         const address = order.deliveryAddress || {};
+        const gstLines = buildGstLineItems(order.gst);
+
+        const gstRowsHtml = gstLines
+                .map(
+                        (item) => `
+                        <tr>
+                                <td style="text-align:right;padding:4px;">${item.label}</td>
+                                <td style="text-align:right;padding:4px;">${formatCurrency(
+                                        item.amount
+                                )}</td>
+                        </tr>`
+                )
+                .join("");
+
+        const gstModeMessage =
+                order?.gst?.mode === "cgst_sgst"
+                        ? "CGST & SGST applied for Bengaluru delivery"
+                        : order?.gst?.mode === "igst"
+                          ? "IGST applied for this delivery"
+                          : "";
 
         return `
                 <h3 style="margin-top:24px;border-bottom:1px solid #e5e7eb;padding-bottom:8px;">Order Summary</h3>
@@ -136,7 +203,7 @@ function buildOrderSummaryHtml(order) {
                                 <td style="text-align:right;padding:4px;">Subtotal:</td>
                                 <td style="text-align:right;padding:4px;">${formatCurrency(order.subtotal)}</td>
                         </tr>
-                        ${order.tax > 0 ? `<tr><td style="text-align:right;padding:4px;">Tax:</td><td style="text-align:right;padding:4px;">${formatCurrency(order.tax)}</td></tr>` : ""}
+                        ${gstRowsHtml}
                         ${order.shippingCost > 0 ? `<tr><td style="text-align:right;padding:4px;">Shipping:</td><td style="text-align:right;padding:4px;">${formatCurrency(order.shippingCost)}</td></tr>` : ""}
                         ${order.discount > 0 ? `<tr><td style="text-align:right;padding:4px;">Discount:</td><td style="text-align:right;padding:4px;">-${formatCurrency(order.discount)}</td></tr>` : ""}
                         <tr>
@@ -152,6 +219,11 @@ function buildOrderSummaryHtml(order) {
                 address.zipCode ? "- " + address.zipCode : ""
         }</p>
                 <p style="margin:0;">${address.country || ""}</p>
+                ${
+                        gstModeMessage
+                                ? `<p style="margin-top:12px;color:#4b5563;font-size:12px;">${gstModeMessage}</p>`
+                                : ""
+                }
         `;
 }
 

--- a/lib/utils/gst.js
+++ b/lib/utils/gst.js
@@ -1,0 +1,135 @@
+export const GST_RATE_PERCENT = 18;
+
+const BANGALORE_KEYWORDS = ["bangalore", "bengaluru", "bengalooru"];
+
+const roundToTwo = (value) => {
+        const numeric = Number(value || 0);
+        if (!Number.isFinite(numeric)) {
+                return 0;
+        }
+        return Math.round(numeric * 100) / 100;
+};
+
+const formatRate = (value) => {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+                return "0";
+        }
+        const fixed = numeric.toFixed(2);
+        return fixed.replace(/\.00$/, "").replace(/(\.[0-9]*[1-9])0+$/, "$1");
+};
+
+const addressMatchesKeyword = (field = "", keywords = BANGALORE_KEYWORDS) => {
+        if (!field) return false;
+        const lower = String(field).toLowerCase();
+        return keywords.some((keyword) => lower.includes(keyword));
+};
+
+export const determineGstMode = (address) => {
+        if (!address) return "igst";
+
+        if (
+                addressMatchesKeyword(address.city) ||
+                (addressMatchesKeyword(address.state) &&
+                        addressMatchesKeyword(address.city, ["bengaluru", "bangalore"])) ||
+                addressMatchesKeyword(address.fullAddress)
+        ) {
+                return "cgst_sgst";
+        }
+
+        return "igst";
+};
+
+export const calculateGstTotals = ({
+        subtotal = 0,
+        discount = 0,
+        shippingCost = 0,
+        address = null,
+        gstMode = null,
+        gstRatePercent = GST_RATE_PERCENT,
+} = {}) => {
+        const safeSubtotal = roundToTwo(subtotal);
+        const safeDiscount = Math.min(roundToTwo(discount), safeSubtotal);
+        const safeShipping = roundToTwo(shippingCost);
+        const taxableAmount = roundToTwo(Math.max(safeSubtotal - safeDiscount, 0));
+        const mode = gstMode || determineGstMode(address);
+        const rate = Number.isFinite(Number(gstRatePercent)) ? Number(gstRatePercent) : GST_RATE_PERCENT;
+        const gstTotal = roundToTwo(taxableAmount * (rate / 100));
+
+        let cgst = 0;
+        let sgst = 0;
+        let igst = 0;
+
+        if (mode === "cgst_sgst") {
+                const half = roundToTwo(gstTotal / 2);
+                cgst = half;
+                sgst = roundToTwo(gstTotal - half);
+        } else {
+                igst = gstTotal;
+        }
+
+        const grandTotal = roundToTwo(taxableAmount + safeShipping + gstTotal);
+
+        return {
+                subtotal: safeSubtotal,
+                discount: safeDiscount,
+                shippingCost: safeShipping,
+                taxableAmount,
+                gst: {
+                        mode,
+                        rate,
+                        cgst,
+                        sgst,
+                        igst,
+                        total: gstTotal,
+                        taxableAmount,
+                },
+                total: grandTotal,
+        };
+};
+
+export const buildGstLineItems = (gst) => {
+        if (!gst) return [];
+
+        const { mode = "igst", rate = GST_RATE_PERCENT } = gst;
+        const lines = [];
+
+        if (mode === "cgst_sgst") {
+                const halfRate = rate / 2;
+                const cgstAmount = roundToTwo(gst.cgst ?? (gst.total ?? 0) / 2);
+                const sgstAmount = roundToTwo(gst.sgst ?? (gst.total ?? 0) / 2);
+
+                if (cgstAmount > 0) {
+                        lines.push({
+                                key: "cgst",
+                                label: `CGST (${formatRate(halfRate)}%)`,
+                                amount: cgstAmount,
+                        });
+                }
+                if (sgstAmount > 0) {
+                        lines.push({
+                                key: "sgst",
+                                label: `SGST (${formatRate(halfRate)}%)`,
+                                amount: sgstAmount,
+                        });
+                }
+        } else {
+                const igstAmount = roundToTwo(gst.igst ?? gst.total ?? 0);
+                if (igstAmount > 0) {
+                        lines.push({
+                                key: "igst",
+                                label: `IGST (${formatRate(rate)}%)`,
+                                amount: igstAmount,
+                        });
+                }
+        }
+
+        return lines;
+};
+
+export default {
+        GST_RATE_PERCENT,
+        determineGstMode,
+        calculateGstTotals,
+        buildGstLineItems,
+};

--- a/model/Order.js
+++ b/model/Order.js
@@ -1,5 +1,40 @@
 import mongoose from "mongoose";
 
+const GstBreakdownSchema = new mongoose.Schema(
+        {
+                mode: {
+                        type: String,
+                        enum: ["igst", "cgst_sgst"],
+                        default: "igst",
+                },
+                rate: {
+                        type: Number,
+                        default: 18,
+                },
+                cgst: {
+                        type: Number,
+                        default: 0,
+                },
+                sgst: {
+                        type: Number,
+                        default: 0,
+                },
+                igst: {
+                        type: Number,
+                        default: 0,
+                },
+                total: {
+                        type: Number,
+                        default: 0,
+                },
+                taxableAmount: {
+                        type: Number,
+                        default: 0,
+                },
+        },
+        { _id: false }
+);
+
 const OrderSchema = new mongoose.Schema(
 	{
 		orderNumber: {
@@ -21,11 +56,24 @@ const OrderSchema = new mongoose.Schema(
 		customerMobile: String,
 
 		// Pricing (combined totals)
-		subtotal: Number,
-		tax: Number,
-		shippingCost: Number,
-		discount: Number,
-		totalAmount: Number,
+                subtotal: Number,
+                tax: Number,
+                shippingCost: Number,
+                discount: Number,
+                taxableAmount: Number,
+                totalAmount: Number,
+                gst: {
+                        type: GstBreakdownSchema,
+                        default: () => ({
+                                mode: "igst",
+                                rate: 18,
+                                cgst: 0,
+                                sgst: 0,
+                                igst: 0,
+                                total: 0,
+                                taxableAmount: 0,
+                        }),
+                },
 
 		// Coupon/Promo
 		couponApplied: {

--- a/model/SubOrder.js
+++ b/model/SubOrder.js
@@ -1,5 +1,40 @@
 import mongoose from "mongoose";
 
+const GstBreakdownSchema = new mongoose.Schema(
+        {
+                mode: {
+                        type: String,
+                        enum: ["igst", "cgst_sgst"],
+                        default: "igst",
+                },
+                rate: {
+                        type: Number,
+                        default: 18,
+                },
+                cgst: {
+                        type: Number,
+                        default: 0,
+                },
+                sgst: {
+                        type: Number,
+                        default: 0,
+                },
+                igst: {
+                        type: Number,
+                        default: 0,
+                },
+                total: {
+                        type: Number,
+                        default: 0,
+                },
+                taxableAmount: {
+                        type: Number,
+                        default: 0,
+                },
+        },
+        { _id: false }
+);
+
 const SubOrderSchema = new mongoose.Schema(
 	{
 		orderId: {
@@ -30,11 +65,24 @@ const SubOrderSchema = new mongoose.Schema(
 		],
 
 		// Pricing for this seller
-		subtotal: Number,
-		tax: Number,
-		shippingCost: Number,
-		discount: Number,
-		totalAmount: Number,
+                subtotal: Number,
+                tax: Number,
+                shippingCost: Number,
+                discount: Number,
+                taxableAmount: Number,
+                totalAmount: Number,
+                gst: {
+                        type: GstBreakdownSchema,
+                        default: () => ({
+                                mode: "igst",
+                                rate: 18,
+                                cgst: 0,
+                                sgst: 0,
+                                igst: 0,
+                                total: 0,
+                                taxableAmount: 0,
+                        }),
+                },
 
 		// Coupon/Promo applied to this sub-order
 		couponApplied: {


### PR DESCRIPTION
## Summary
- add reusable GST helpers and use them to calculate totals during checkout, order creation, and admin flows
- extend order and sub-order persistence to capture GST breakdowns and expose them via the admin APIs
- refresh email and PDF invoice generation to render IGST/CGST/SGST line items instead of a generic tax row
