### PR TITLE
Fix missing Review model registration in product API

### DIFF
--- a/app/api/product/[id]/route.js
+++ b/app/api/product/[id]/route.js
@@ -1,4 +1,5 @@
 import Product from "@/model/Product.js";
+import Review from "@/model/Review.js";
 import companyDetails from "@/model/companyDetails.js";
 import { dbConnect } from "@/lib/dbConnect.js";
 
@@ -8,7 +9,11 @@ export async function GET(req, { params }) {
 	const { id } = await params;
 
 	try {
-		const product = await Product.findById(id).populate("reviews", "rating");
+                const product = await Product.findById(id).populate({
+                        path: "reviews",
+                        select: "rating",
+                        model: Review,
+                });
 
 		if (!product) {
 			return Response.json({ message: "Product not found" }, { status: 404 });


### PR DESCRIPTION
## Summary
- import the Review model in the product details API route so Mongoose registers it
- populate product reviews using the registered Review model when fetching rating data

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68d10dc48240832e99e2183e7755b3ca