### PR TITLE
Implement subcategory selection and import support

### DIFF
--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -20,6 +20,8 @@ import { X, Plus, User } from "lucide-react"
 import { useAdminProductStore } from "@/store/adminProductStore.js"
 import { ImageUpload } from "@/components/AdminPanel/ImageUpload.jsx"
 
+const normalizeValue = (value) => (typeof value === "string" ? value.trim().toLowerCase() : "")
+
 const productTypes = [
   { value: "featured", label: "Featured" },
   { value: "top-selling", label: "Top Selling" },
@@ -182,6 +184,35 @@ export function AddProductPopup({ open, onOpenChange }) {
     setFeatures(updatedFeatures)
   }
 
+  const selectedCategory = categories.find(
+    (category) => normalizeValue(category.name) === normalizeValue(formData.category)
+  )
+
+  const availableSubCategories = selectedCategory?.subCategories ?? []
+
+  useEffect(() => {
+    if (!categories.length) return
+
+    const currentCategory = categories.find(
+      (category) => normalizeValue(category.name) === normalizeValue(formData.category)
+    )
+
+    if (!currentCategory) {
+      if (formData.subCategory) {
+        setFormData((prev) => ({ ...prev, subCategory: "" }))
+      }
+      return
+    }
+
+    const hasValidSubCategory = (currentCategory.subCategories || []).some(
+      (subCategory) => normalizeValue(subCategory.name) === normalizeValue(formData.subCategory)
+    )
+
+    if (!hasValidSubCategory && formData.subCategory) {
+      setFormData((prev) => ({ ...prev, subCategory: "" }))
+    }
+  }, [categories, formData.category, formData.subCategory])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
@@ -204,7 +235,9 @@ export function AddProductPopup({ open, onOpenChange }) {
                 <Label>Select Seller *</Label>
                 <Select
                   value={formData.sellerId}
-                  onValueChange={(value) => setFormData({ ...formData, sellerId: value })}
+                  onValueChange={(value) =>
+                    setFormData((prev) => ({ ...prev, sellerId: value }))
+                  }
                   disabled={loadingSellers}
                 >
                   <SelectTrigger className="mt-1">
@@ -292,7 +325,9 @@ export function AddProductPopup({ open, onOpenChange }) {
                 <Label>Category *</Label>
                 <Select
                   value={formData.category}
-                  onValueChange={(value) => setFormData({ ...formData, category: value })}
+                  onValueChange={(value) =>
+                    setFormData((prev) => ({ ...prev, category: value, subCategory: "" }))
+                  }
                 >
                   <SelectTrigger className="mt-1">
                     <SelectValue placeholder="Select category" />
@@ -309,12 +344,31 @@ export function AddProductPopup({ open, onOpenChange }) {
 
               <div>
                 <Label>Sub Category</Label>
-                <Input
-                  placeholder="Enter sub category"
-                  value={formData.subCategory}
-                  onChange={(e) => setFormData({ ...formData, subCategory: e.target.value })}
-                  className="mt-1"
-                />
+                <Select
+                  value={formData.subCategory || ""}
+                  onValueChange={(value) =>
+                    setFormData((prev) => ({ ...prev, subCategory: value }))
+                  }
+                  disabled={!availableSubCategories.length}
+                >
+                  <SelectTrigger className="mt-1">
+                    <SelectValue
+                      placeholder={
+                        availableSubCategories.length
+                          ? "Select sub category"
+                          : "No subcategories available"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">No subcategory</SelectItem>
+                    {availableSubCategories.map((subCategory) => (
+                      <SelectItem key={subCategory.name} value={subCategory.name}>
+                        {subCategory.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
 
               <div>

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -100,44 +100,46 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 		setIsSubmitting(false);
 	};
 
-	const csvHeaders = [
-		"Product Category",
-		"HSN Code",
-		"Product title",
-		"Description",
-		"Sale Price",
-		"MRP",
-		"Feature Image URL link 1",
-		"Image URL link 2",
-		"Image URL link 3",
-		"Image URL link 4",
-		"Image URL link 5",
-		"Bullet Point 1",
-		"Bullet Point 2",
-		"Bullet Point 3",
-		"Bullet Point 4",
-		"Bullet Point 5",
-		"Generic Keywords",
-		"Length (cm)",
-		"Width (cm)",
-		"height (cm)",
-		"Weight (Kg)",
-		"Colour",
-		"Material used / Made Of",
-		"brand",
-		"size",
-	];
+        const csvHeaders = [
+                "Product Category",
+                "Product Subcategory",
+                "HSN Code",
+                "Product title",
+                "Description",
+                "Sale Price",
+                "MRP",
+                "Feature Image URL link 1",
+                "Image URL link 2",
+                "Image URL link 3",
+                "Image URL link 4",
+                "Image URL link 5",
+                "Bullet Point 1",
+                "Bullet Point 2",
+                "Bullet Point 3",
+                "Bullet Point 4",
+                "Bullet Point 5",
+                "Generic Keywords",
+                "Length (cm)",
+                "Width (cm)",
+                "height (cm)",
+                "Weight (Kg)",
+                "Colour",
+                "Material used / Made Of",
+                "brand",
+                "size",
+        ];
 
 	const downloadTemplate = () => {
 		if (mode === "json") {
-			const template = [
-				{
-					title: "Sample Product 1",
-					description: "This is a sample product description",
-					longDescription:
-						"This is a detailed description of the sample product",
-					category: "personal-safety",
-					price: 99.99,
+                        const template = [
+                                {
+                                        title: "Sample Product 1",
+                                        description: "This is a sample product description",
+                                        longDescription:
+                                                "This is a detailed description of the sample product",
+                                        category: "personal-safety",
+                                        subCategory: "ppe",
+                                        price: 99.99,
 					salePrice: 79.99,
 					stocks: 100,
 					discount: 20,
@@ -163,10 +165,11 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 			a.click();
 			window.URL.revokeObjectURL(url);
 		} else {
-			const sample = [
-				"personal-safety",
-				"HSN001",
-				"Sample Product",
+                        const sample = [
+                                "personal-safety",
+                                "ppe",
+                                "HSN001",
+                                "Sample Product",
 				"Sample Description",
 				"79.99",
 				"99.99",
@@ -293,9 +296,10 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 		const discount =
 			price && salePrice ? ((price - salePrice) / price) * 100 : 0;
 
-		return {
-			category: row["Product Category"] || "",
-			hsnCode: row["HSN Code"] || "",
+                return {
+                        category: row["Product Category"] || "",
+                        subCategory: row["Product Subcategory"] || "",
+                        hsnCode: row["HSN Code"] || "",
 			title: row["Product title"] || "",
 			description: row["Description"] || "",
 			longDescription: row["Description"] || "",

--- a/components/AdminPanel/Popups/UpdateProductPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateProductPopup.jsx
@@ -26,6 +26,8 @@ import { Plus, X, User } from "lucide-react";
 import { useAdminProductStore } from "@/store/adminProductStore.js";
 import { ImageUpload } from "@/components/AdminPanel/ImageUpload.jsx";
 
+const normalizeValue = (value) => (typeof value === "string" ? value.trim().toLowerCase() : "");
+
 const productTypes = [
 	{ value: "featured", label: "Featured" },
 	{ value: "top-selling", label: "Top Selling" },
@@ -233,13 +235,43 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 		setFeatures(features.filter((_, i) => i !== index));
 	};
 
-	const updateFeature = (index, field, value) => {
-		const updatedFeatures = [...features];
-		updatedFeatures[index][field] = value;
-		setFeatures(updatedFeatures);
-	};
+        const updateFeature = (index, field, value) => {
+                const updatedFeatures = [...features];
+                updatedFeatures[index][field] = value;
+                setFeatures(updatedFeatures);
+        };
 
-	return (
+        const selectedCategory = categories.find(
+                (category) => normalizeValue(category.name) === normalizeValue(formData.category)
+        );
+
+        const availableSubCategories = selectedCategory?.subCategories ?? [];
+
+        useEffect(() => {
+                if (!categories.length) return;
+
+                const currentCategory = categories.find(
+                        (category) => normalizeValue(category.name) === normalizeValue(formData.category)
+                );
+
+                if (!currentCategory) {
+                        if (formData.subCategory) {
+                                setFormData((prev) => ({ ...prev, subCategory: "" }));
+                        }
+                        return;
+                }
+
+                const hasValidSubCategory = (currentCategory.subCategories || []).some(
+                        (subCategory) =>
+                                normalizeValue(subCategory.name) === normalizeValue(formData.subCategory)
+                );
+
+                if (!hasValidSubCategory && formData.subCategory) {
+                        setFormData((prev) => ({ ...prev, subCategory: "" }));
+                }
+        }, [categories, formData.category, formData.subCategory]);
+
+        return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
 				<motion.div
@@ -261,13 +293,16 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 							{/* Seller Selection */}
 							<div className="md:col-span-2">
 								<Label>Select Seller *</Label>
-								<Select
-									value={formData.sellerId}
-									onValueChange={(value) =>
-										setFormData({ ...formData, sellerId: value })
-									}
-									disabled={loadingSellers}
-								>
+                                                                <Select
+                                                                        value={formData.sellerId}
+                                                                        onValueChange={(value) =>
+                                                                                setFormData((prev) => ({
+                                                                                        ...prev,
+                                                                                        sellerId: value,
+                                                                                }))
+                                                                        }
+                                                                        disabled={loadingSellers}
+                                                                >
 									<SelectTrigger className="mt-1">
 										<SelectValue
 											placeholder={
@@ -370,17 +405,21 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 								/>
 							</div>
 
-							<div>
-								<Label>Category *</Label>
-								<Select
-									value={formData.category}
-									onValueChange={(value) =>
-										setFormData({ ...formData, category: value })
-									}
-								>
-									<SelectTrigger className="mt-1">
-										<SelectValue placeholder="Select category" />
-									</SelectTrigger>
+                                                        <div>
+                                                                <Label>Category *</Label>
+                                                                <Select
+                                                                        value={formData.category}
+                                                                        onValueChange={(value) =>
+                                                                                setFormData((prev) => ({
+                                                                                        ...prev,
+                                                                                        category: value,
+                                                                                        subCategory: "",
+                                                                                }))
+                                                                        }
+                                                                >
+                                                                        <SelectTrigger className="mt-1">
+                                                                                <SelectValue placeholder="Select category" />
+                                                                        </SelectTrigger>
 									<SelectContent>
 										{categories.map((category) => (
 											<SelectItem key={category._id} value={category.name}>
@@ -391,17 +430,37 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 								</Select>
 							</div>
 
-							<div>
-								<Label>Sub Category</Label>
-								<Input
-									placeholder="Enter sub category"
-									value={formData.subCategory}
-									onChange={(e) =>
-										setFormData({ ...formData, subCategory: e.target.value })
-									}
-									className="mt-1"
-								/>
-							</div>
+                                                        <div>
+                                                                <Label>Sub Category</Label>
+                                                                <Select
+                                                                        value={formData.subCategory || ""}
+                                                                        onValueChange={(value) =>
+                                                                                setFormData((prev) => ({
+                                                                                        ...prev,
+                                                                                        subCategory: value,
+                                                                                }))
+                                                                        }
+                                                                        disabled={!availableSubCategories.length}
+                                                                >
+                                                                        <SelectTrigger className="mt-1">
+                                                                                <SelectValue
+                                                                                        placeholder={
+                                                                                                availableSubCategories.length
+                                                                                                        ? "Select sub category"
+                                                                                                        : "No subcategories available"
+                                                                                        }
+                                                                                />
+                                                                        </SelectTrigger>
+                                                                        <SelectContent>
+                                                                                <SelectItem value="">No subcategory</SelectItem>
+                                                                                {availableSubCategories.map((subCategory) => (
+                                                                                        <SelectItem key={subCategory.name} value={subCategory.name}>
+                                                                                                {subCategory.name}
+                                                                                        </SelectItem>
+                                                                                ))}
+                                                                        </SelectContent>
+                                                                </Select>
+                                                        </div>
 
 							<div>
 								<Label>Product Type</Label>


### PR DESCRIPTION
## Summary
- restrict the admin product subcategory field to existing category subcategories during add and edit flows
- reset invalid or stale subcategory selections when the category changes
- extend the admin bulk upload template and parser to include a product subcategory column
