### PR TITLE
Add recommended coupon support for buyers

### DIFF
--- a/app/(buyers)/order-success/page.jsx
+++ b/app/(buyers)/order-success/page.jsx
@@ -41,29 +41,35 @@ export default function OrderSuccessPage() {
 				const products =
 					orderData?.subOrders?.flatMap((sub) => sub.products) || [];
 
-				setOrderDetails({
-					orderId,
-					orderNumber,
-					estimatedDelivery: new Date(
-						Date.now() + 7 * 24 * 60 * 60 * 1000
-					).toLocaleDateString("en-IN", {
-						year: "numeric",
-						month: "short",
-						day: "numeric",
-					}),
-					products, // save all products
-					amount: orderData?.totalAmount,
-					discount: orderData?.discount,
-					paymentMethod: orderData?.paymentMethod,
-					orderDate: orderData?.orderDate,
-					customer: {
-						name: orderData?.customerName,
-						email: orderData?.customerEmail,
-						mobile: orderData?.customerMobile,
-					},
-					address: orderData?.deliveryAddress,
-					status: orderData?.status,
-				});
+                                setOrderDetails({
+                                        orderId,
+                                        orderNumber,
+                                        estimatedDelivery: new Date(
+                                                Date.now() + 7 * 24 * 60 * 60 * 1000
+                                        ).toLocaleDateString("en-IN", {
+                                                year: "numeric",
+                                                month: "short",
+                                                day: "numeric",
+                                        }),
+                                        products, // save all products
+                                        amount: orderData?.totalAmount || 0,
+                                        discount: orderData?.discount || 0,
+                                        paymentMethod: orderData?.paymentMethod,
+                                        orderDate: orderData?.orderDate,
+                                        customer: {
+                                                name: orderData?.customerName,
+                                                email: orderData?.customerEmail,
+                                                mobile: orderData?.customerMobile,
+                                        },
+                                        address: orderData?.deliveryAddress,
+                                        status: orderData?.status,
+                                        coupon: orderData?.couponApplied
+                                                ? {
+                                                          code: orderData.couponApplied.couponCode,
+                                                          amount: orderData.couponApplied.discountAmount || 0,
+                                                  }
+                                                : null,
+                                });
 			} catch (err) {
 				console.error("Failed to fetch order details", err);
 			}
@@ -218,17 +224,32 @@ export default function OrderSuccessPage() {
 							</div>
 
 							{/* Order summary */}
-							<div className="border-t pt-3 space-y-2">
-								<div className="flex justify-between items-center">
-									<span className="text-gray-600">Order Amount:</span>
-									<span className="font-medium">₹{orderDetails.amount}</span>
-								</div>
-								<div className="flex justify-between items-center">
-									<span className="text-gray-600">Discount:</span>
-									<span className="font-medium">₹{orderDetails.discount}</span>
-								</div>
-								<div className="flex justify-between items-center">
-									<span className="text-gray-600">Payment Method:</span>
+                                                        <div className="border-t pt-3 space-y-2">
+                                                                <div className="flex justify-between items-center">
+                                                                        <span className="text-gray-600">Order Amount:</span>
+                                                                        <span className="font-medium">
+                                                                                ₹{Number(orderDetails.amount || 0).toLocaleString("en-IN")}
+                                                                        </span>
+                                                                </div>
+                                                                {orderDetails.coupon && (
+                                                                        <div className="flex justify-between items-center">
+                                                                                <span className="text-gray-600">Coupon:</span>
+                                                                                <span className="flex items-center gap-2 font-medium text-green-700">
+                                                                                        <Badge variant="secondary" className="bg-green-100 text-green-700">
+                                                                                                {orderDetails.coupon.code}
+                                                                                        </Badge>
+                                                                                        -₹{Number(orderDetails.coupon.amount || 0).toLocaleString("en-IN")}
+                                                                                </span>
+                                                                        </div>
+                                                                )}
+                                                                <div className="flex justify-between items-center">
+                                                                        <span className="text-gray-600">Discount:</span>
+                                                                        <span className="font-medium text-green-700">
+                                                                                -₹{Number(orderDetails.discount || 0).toLocaleString("en-IN")}
+                                                                        </span>
+                                                                </div>
+                                                                <div className="flex justify-between items-center">
+                                                                        <span className="text-gray-600">Payment Method:</span>
 									<Badge className="font-medium bg-blue-300 text-blue-600 rounded-xl">
 										{orderDetails.paymentMethod}
 									</Badge>

--- a/app/admin/catalog/coupons/page.jsx
+++ b/app/admin/catalog/coupons/page.jsx
@@ -133,9 +133,13 @@ export default function AdminCouponsPage() {
 		}
 	};
 
-	const handlePublishToggle = async (couponId, published) => {
-		await updateCoupon(couponId, { published });
-	};
+        const handlePublishToggle = async (couponId, published) => {
+                await updateCoupon(couponId, { published });
+        };
+
+        const handleRecommendedToggle = async (couponId, recommended) => {
+                await updateCoupon(couponId, { recommended });
+        };
 
 	const handleSort = (field) => {
 		const currentOrder = filters.sortOrder === "desc" ? "asc" : "desc";
@@ -366,8 +370,9 @@ export default function AdminCouponsPage() {
 													<ArrowUpDown className="ml-2 h-4 w-4" />
 												</Button>
 											</TableHead>
-											<TableHead>Status</TableHead>
-											<TableHead>Published</TableHead>
+                                                                                        <TableHead>Status</TableHead>
+                                                                                        <TableHead>Recommended</TableHead>
+                                                                                        <TableHead>Published</TableHead>
 											<TableHead>Actions</TableHead>
 										</TableRow>
 									</TableHeader>
@@ -392,14 +397,21 @@ export default function AdminCouponsPage() {
 														<div className="w-10 h-10 bg-gradient-to-br from-orange-500 to-red-600 rounded-lg flex items-center justify-center text-white">
 															<Percent className="w-5 h-5" />
 														</div>
-														<div>
-															<div className="font-medium">{coupon.name}</div>
-															<div className="text-sm text-gray-500">
-																Campaign
-															</div>
-														</div>
-													</div>
-												</TableCell>
+                                                                                                                <div>
+                                                                                                                        <div className="flex items-center gap-2">
+                                                                                                                                <span className="font-medium">{coupon.name}</span>
+                                                                                                                                {coupon.recommended && (
+                                                                                                                                        <Badge className="bg-blue-50 text-blue-700 border border-blue-200">
+                                                                                                                                                Recommended
+                                                                                                                                        </Badge>
+                                                                                                                                )}
+                                                                                                                        </div>
+                                                                                                                        <div className="text-sm text-gray-500">
+                                                                                                                                Campaign
+                                                                                                                        </div>
+                                                                                                                </div>
+                                                                                                       </div>
+                                                                                               </TableCell>
 												<TableCell>
 													<div className="font-mono font-bold text-blue-600 bg-blue-50 px-2 py-1 rounded text-sm inline-block">
 														{coupon.code}
@@ -429,16 +441,27 @@ export default function AdminCouponsPage() {
 														</span>
 													</div>
 												</TableCell>
-												<TableCell>
-													<Badge className={getStatusColor(coupon.status)}>
-														{coupon.status}
-													</Badge>
-												</TableCell>
-												<TableCell>
-													<Switch
-														checked={coupon.published}
-														onCheckedChange={(checked) =>
-															handlePublishToggle(coupon._id, checked)
+                                                                                                <TableCell>
+                                                                                                        <Badge className={getStatusColor(coupon.status)}>
+                                                                                                                {coupon.status}
+                                                                                                        </Badge>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <Switch
+                                                                                                                checked={coupon.recommended}
+                                                                                                                onCheckedChange={(checked) =>
+                                                                                                                        handleRecommendedToggle(
+                                                                                                                                coupon._id,
+                                                                                                                                checked
+                                                                                                                        )
+                                                                                                                }
+                                                                                                        />
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <Switch
+                                                                                                                checked={coupon.published}
+                                                                                                                onCheckedChange={(checked) =>
+                                                                                                                        handlePublishToggle(coupon._id, checked)
 														}
 													/>
 												</TableCell>

--- a/app/api/coupons/recommended/route.js
+++ b/app/api/coupons/recommended/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/lib/dbConnect.js";
+import Promocode from "@/model/Promocode.js";
+
+export async function GET() {
+        try {
+                await dbConnect();
+
+                const now = new Date();
+                const coupons = await Promocode.find({
+                        published: true,
+                        recommended: true,
+                        status: "Active",
+                        startDate: { $lte: now },
+                        endDate: { $gte: now },
+                })
+                        .sort({ endDate: 1 })
+                        .limit(10)
+                        .lean();
+
+                return NextResponse.json({ success: true, coupons }, { status: 200 });
+        } catch (error) {
+                console.error("Recommended coupons fetch error:", error);
+                return NextResponse.json(
+                        { success: false, message: "Failed to load coupons" },
+                        { status: 500 }
+                );
+        }
+}

--- a/components/AdminPanel/Popups/AddCouponPopup.jsx
+++ b/components/AdminPanel/Popups/AddCouponPopup.jsx
@@ -21,23 +21,24 @@ export function AddCouponPopup({ open, onOpenChange }) {
 	const { addCoupon, generateCouponCode } = useAdminCouponStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		name: "",
-		code: "",
-		discount: "",
-		startDate: "",
-		endDate: "",
-		published: true,
-	});
+        const [formData, setFormData] = useState({
+                name: "",
+                code: "",
+                discount: "",
+                startDate: "",
+                endDate: "",
+                published: true,
+                recommended: false,
+        });
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		setIsSubmitting(true);
 
-		const couponData = {
-			...formData,
-			discount: Number.parseFloat(formData.discount),
-		};
+                const couponData = {
+                        ...formData,
+                        discount: Number.parseFloat(formData.discount),
+                };
 
 		const success = await addCoupon(couponData);
 		if (success) {
@@ -48,14 +49,15 @@ export function AddCouponPopup({ open, onOpenChange }) {
 	};
 
 	const resetForm = () => {
-		setFormData({
-			name: "",
-			code: "",
-			discount: "",
-			startDate: "",
-			endDate: "",
-			published: true,
-		});
+                setFormData({
+                        name: "",
+                        code: "",
+                        discount: "",
+                        startDate: "",
+                        endDate: "",
+                        published: true,
+                        recommended: false,
+                });
 	};
 
 	const handleGenerateCode = () => {
@@ -197,20 +199,35 @@ export function AddCouponPopup({ open, onOpenChange }) {
 							</div>
 						</div>
 
-						<div className="flex items-center justify-between">
-							<div>
-								<Label>Publish Coupon</Label>
-								<p className="text-sm text-gray-500">
-									Make this coupon available to customers
-								</p>
-							</div>
-							<Switch
-								checked={formData.published}
-								onCheckedChange={(checked) =>
-									setFormData({ ...formData, published: checked })
-								}
-							/>
-						</div>
+                                                <div className="flex items-center justify-between">
+                                                        <div>
+                                                                <Label>Publish Coupon</Label>
+                                                                <p className="text-sm text-gray-500">
+                                                                        Make this coupon available to customers
+                                                                </p>
+                                                        </div>
+                                                        <Switch
+                                                                checked={formData.published}
+                                                                onCheckedChange={(checked) =>
+                                                                        setFormData({ ...formData, published: checked })
+                                                                }
+                                                        />
+                                                </div>
+
+                                                <div className="flex items-center justify-between">
+                                                        <div>
+                                                                <Label>Recommend Coupon</Label>
+                                                                <p className="text-sm text-gray-500">
+                                                                        Highlight this coupon for shoppers
+                                                                </p>
+                                                        </div>
+                                                        <Switch
+                                                                checked={formData.recommended}
+                                                                onCheckedChange={(checked) =>
+                                                                        setFormData({ ...formData, recommended: checked })
+                                                                }
+                                                        />
+                                                </div>
 
 						<DialogFooter className="flex gap-3 mt-6">
 							<Button

--- a/components/AdminPanel/Popups/UpdateCouponPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCouponPopup.jsx
@@ -21,14 +21,15 @@ export function UpdateCouponPopup({ open, onOpenChange, coupon }) {
 	const { updateCoupon } = useAdminCouponStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		name: "",
-		code: "",
-		discount: "",
-		startDate: "",
-		endDate: "",
-		published: true,
-	});
+        const [formData, setFormData] = useState({
+                name: "",
+                code: "",
+                discount: "",
+                startDate: "",
+                endDate: "",
+                published: true,
+                recommended: false,
+        });
 
 	useEffect(() => {
 		if (coupon) {
@@ -39,13 +40,15 @@ export function UpdateCouponPopup({ open, onOpenChange, coupon }) {
 				startDate: coupon.startDate
 					? new Date(coupon.startDate).toISOString().split("T")[0]
 					: "",
-				endDate: coupon.endDate
-					? new Date(coupon.endDate).toISOString().split("T")[0]
-					: "",
-				published: coupon.published !== undefined ? coupon.published : true,
-			});
-		}
-	}, [coupon]);
+                                endDate: coupon.endDate
+                                        ? new Date(coupon.endDate).toISOString().split("T")[0]
+                                        : "",
+                                published: coupon.published !== undefined ? coupon.published : true,
+                                recommended:
+                                        coupon.recommended !== undefined ? coupon.recommended : false,
+                        });
+                }
+        }, [coupon]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -53,10 +56,10 @@ export function UpdateCouponPopup({ open, onOpenChange, coupon }) {
 
 		setIsSubmitting(true);
 
-		const updateData = {
-			...formData,
-			discount: Number.parseFloat(formData.discount),
-		};
+                const updateData = {
+                        ...formData,
+                        discount: Number.parseFloat(formData.discount),
+                };
 
 		const success = await updateCoupon(coupon._id, updateData);
 		if (success) {
@@ -176,20 +179,35 @@ export function UpdateCouponPopup({ open, onOpenChange, coupon }) {
 							</div>
 						</div>
 
-						<div className="flex items-center justify-between">
-							<div>
-								<Label>Publish Coupon</Label>
-								<p className="text-sm text-gray-500">
-									Make this coupon available to customers
-								</p>
-							</div>
-							<Switch
-								checked={formData.published}
-								onCheckedChange={(checked) =>
-									setFormData({ ...formData, published: checked })
-								}
-							/>
-						</div>
+                                                <div className="flex items-center justify-between">
+                                                        <div>
+                                                                <Label>Publish Coupon</Label>
+                                                                <p className="text-sm text-gray-500">
+                                                                        Make this coupon available to customers
+                                                                </p>
+                                                        </div>
+                                                        <Switch
+                                                                checked={formData.published}
+                                                                onCheckedChange={(checked) =>
+                                                                        setFormData({ ...formData, published: checked })
+                                                                }
+                                                        />
+                                                </div>
+
+                                                <div className="flex items-center justify-between">
+                                                        <div>
+                                                                <Label>Recommend Coupon</Label>
+                                                                <p className="text-sm text-gray-500">
+                                                                        Highlight this coupon for shoppers
+                                                                </p>
+                                                        </div>
+                                                        <Switch
+                                                                checked={formData.recommended}
+                                                                onCheckedChange={(checked) =>
+                                                                        setFormData({ ...formData, recommended: checked })
+                                                                }
+                                                        />
+                                                </div>
 
 						<DialogFooter className="flex gap-3 mt-6">
 							<Button

--- a/components/BuyerPanel/cart/CartSummary.jsx
+++ b/components/BuyerPanel/cart/CartSummary.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -14,23 +14,51 @@ export default function CartSummary() {
 	const router = useRouter();
 	const [couponCode, setCouponCode] = useState("");
 
-	const {
-		totals,
-		appliedPromo,
-		applyPromoCode,
-		removePromoCode,
-		items,
-		isLoading,
-	} = useCartStore();
+        const {
+                totals,
+                appliedPromo,
+                applyPromoCode,
+                removePromoCode,
+                items,
+                isLoading,
+                recommendedCoupons,
+                recommendedLoading,
+                fetchRecommendedCoupons,
+        } = useCartStore();
 
-	const handleApplyCoupon = async () => {
-		if (!couponCode.trim()) return;
+        useEffect(() => {
+                fetchRecommendedCoupons();
+        }, [fetchRecommendedCoupons]);
 
-		const success = await applyPromoCode(couponCode.trim());
-		if (success) {
-			setCouponCode("");
-		}
-	};
+        const discountAmount = useMemo(() => {
+                if (!appliedPromo) return 0;
+                if (appliedPromo.discountAmount !== undefined) {
+                        return appliedPromo.discountAmount;
+                }
+
+                const discountValue = appliedPromo.discount || 0;
+                return Math.round((totals.subtotal * discountValue) / 100);
+        }, [appliedPromo, totals.subtotal]);
+
+        const discountPercent = useMemo(() => {
+                if (!appliedPromo) return 0;
+                if (appliedPromo.discount !== undefined) {
+                        return appliedPromo.discount;
+                }
+
+                if (totals.subtotal === 0) return 0;
+                return Math.round((discountAmount / totals.subtotal) * 100);
+        }, [appliedPromo, discountAmount, totals.subtotal]);
+
+        const handleApplyCoupon = async (codeOverride) => {
+                const codeToApply = (codeOverride || couponCode).trim();
+                if (!codeToApply) return;
+
+                const success = await applyPromoCode(codeToApply);
+                if (success && !codeOverride) {
+                        setCouponCode("");
+                }
+        };
 
 	const handleCheckout = () => {
 		router.push("/checkout");
@@ -46,56 +74,128 @@ export default function CartSummary() {
 				<CardTitle>Order Summary</CardTitle>
 			</CardHeader>
 			<CardContent className="space-y-4">
-				{/* Coupon Section */}
-				{/* <div className="space-y-3">
-					{appliedPromo ? (
-						<div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
-							<div className="flex items-center gap-2">
-								<Tag className="h-4 w-4 text-green-600" />
-								<span className="text-sm font-medium text-green-800">
-									{appliedPromo.code}
-								</span>
-							</div>
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={removePromoCode}
-								className="text-red-600 hover:text-red-700"
-								disabled={isLoading}
-							>
-								<X className="h-4 w-4" />
-							</Button>
-						</div>
-					) : (
-						<>
-							<div className="flex gap-2">
-								<Input
-									placeholder="Enter coupon code"
-									value={couponCode}
-									onChange={(e) => setCouponCode(e.target.value)}
-									className="flex-1"
-									disabled={isLoading}
-								/>
-								<Button
-									variant="outline"
-									onClick={handleApplyCoupon}
-									disabled={isLoading || !couponCode.trim()}
-								>
-									{isLoading ? (
-										<Loader2 className="h-4 w-4 animate-spin" />
-									) : (
-										"Apply"
-									)}
-								</Button>
-							</div>
-							<p className="text-xs text-gray-500">
-								Try "MQXE0KDU" for 20% off
-							</p>
-						</>
-					)}
-				</div> */}
+                                {/* Coupon Section */}
+                                <div className="space-y-3">
+                                        {appliedPromo ? (
+                                                <div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
+                                                        <div>
+                                                                <div className="flex items-center gap-2">
+                                                                        <Tag className="h-4 w-4 text-green-600" />
+                                                                        <span className="text-sm font-medium text-green-800">
+                                                                                {appliedPromo.code}
+                                                                        </span>
+                                                                        {discountPercent > 0 && (
+                                                                                <Badge className="bg-green-100 text-green-700">
+                                                                                        {discountPercent}% OFF
+                                                                                </Badge>
+                                                                        )}
+                                                                </div>
+                                                                {discountAmount > 0 && (
+                                                                        <p className="text-xs text-green-700 mt-1">
+                                                                                You saved ₹{discountAmount.toLocaleString()}
+                                                                        </p>
+                                                                )}
+                                                        </div>
+                                                        <Button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={removePromoCode}
+                                                                className="text-red-600 hover:text-red-700"
+                                                                disabled={isLoading}
+                                                        >
+                                                                <X className="h-4 w-4" />
+                                                        </Button>
+                                                </div>
+                                        ) : (
+                                                <>
+                                                        <div className="flex gap-2">
+                                                                <Input
+                                                                        placeholder="Enter coupon code"
+                                                                        value={couponCode}
+                                                                        onChange={(e) => setCouponCode(e.target.value)}
+                                                                        className="flex-1"
+                                                                        disabled={isLoading}
+                                                                />
+                                                                <Button
+                                                                        variant="outline"
+                                                                        onClick={() => handleApplyCoupon()}
+                                                                        disabled={isLoading || !couponCode.trim()}
+                                                                >
+                                                                        {isLoading ? (
+                                                                                <Loader2 className="h-4 w-4 animate-spin" />
+                                                                        ) : (
+                                                                                "Apply"
+                                                                        )}
+                                                                </Button>
+                                                        </div>
+                                                        <p className="text-xs text-gray-500">
+                                                                Have a coupon? Enter it above or pick one from our recommendations.
+                                                        </p>
+                                                </>
+                                        )}
 
-				{/* <Separator /> */}
+                                        <div className="space-y-2">
+                                                <div className="flex items-center justify-between">
+                                                        <p className="text-sm font-medium text-gray-700">
+                                                                Recommended Coupons
+                                                        </p>
+                                                        {recommendedLoading && (
+                                                                <span className="text-xs text-gray-500">Loading...</span>
+                                                        )}
+                                                </div>
+                                                {!recommendedLoading && recommendedCoupons.length === 0 && (
+                                                        <p className="text-xs text-gray-500">
+                                                                No active coupons are available at the moment.
+                                                        </p>
+                                                )}
+                                                <div className="space-y-2">
+                                                        {recommendedCoupons.map((coupon) => {
+                                                                const isApplied = appliedPromo?.code === coupon.code;
+                                                                const expiryLabel = coupon.endDate
+                                                                        ? new Date(coupon.endDate).toLocaleDateString("en-IN", {
+                                                                                  month: "short",
+                                                                                  day: "numeric",
+                                                                                  year: "numeric",
+                                                                          })
+                                                                        : null;
+
+                                                                return (
+                                                                        <div
+                                                                                key={coupon._id}
+                                                                                className="flex items-center justify-between rounded-lg border border-dashed border-gray-200 p-3"
+                                                                        >
+                                                                                <div>
+                                                                                        <div className="flex items-center gap-2">
+                                                                                                <span className="font-semibold tracking-wide text-sm">
+                                                                                                        {coupon.code}
+                                                                                                </span>
+                                                                                                <Badge variant="secondary" className="text-xs">
+                                                                                                        {coupon.discount}% OFF
+                                                                                                </Badge>
+                                                                                        </div>
+                                                                                        {coupon.name && (
+                                                                                                <p className="text-xs text-gray-600 mt-1">{coupon.name}</p>
+                                                                                        )}
+                                                                                        {expiryLabel && (
+                                                                                                <p className="text-xs text-gray-400">Valid till {expiryLabel}</p>
+                                                                                        )}
+                                                                                </div>
+                                                                                <Button
+                                                                                        variant={isApplied ? "secondary" : "outline"}
+                                                                                        size="sm"
+                                                                                        disabled={isLoading || isApplied}
+                                                                                        onClick={() => handleApplyCoupon(coupon.code)}
+                                                                                >
+                                                                                        {isApplied ? "Applied" : "Apply"}
+                                                                                </Button>
+                                                                        </div>
+                                                                );
+                                                        })}
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <Separator />
 
 				{/* Order Breakdown */}
 				<div className="space-y-2">
@@ -105,12 +205,19 @@ export default function CartSummary() {
 						</span>
 						<span>₹{totals.subtotal.toLocaleString()}</span>
 					</div>
-					{totals.discount > 0 && (
-						<div className="flex justify-between text-green-600">
-							<span>Discount</span>
-							<span>-₹{totals.discount.toLocaleString()}</span>
-						</div>
-					)}
+                                        {totals.discount > 0 && (
+                                                <div className="flex justify-between text-green-600">
+                                                        <span className="flex items-center gap-2">
+                                                                Discount
+                                                                {appliedPromo?.code && (
+                                                                        <Badge className="bg-green-100 text-green-700">
+                                                                                {appliedPromo.code}
+                                                                        </Badge>
+                                                                )}
+                                                        </span>
+                                                        <span>-₹{totals.discount.toLocaleString()}</span>
+                                                </div>
+                                        )}
 
 					<Separator />
 

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -267,16 +267,17 @@ export const generateInvoicePDF = async (order) => {
                         doc.setTextColor(0, 0, 0);
                 }
 
-		if (order.couponApplied && order.couponApplied.discountAmount > 0) {
-			yPosition += 8;
-			doc.setTextColor(59, 130, 246); // Blue color
-			doc.text(`Coupon (${order.couponApplied.couponCode}):`, 150, yPosition);
-			// doc.text(
-			// 	`-${order.couponApplied.discountAmount.toFixed(2)}`,
-			// 	175,
-			// 	yPosition
-			// );
-		}
+                if (order.couponApplied && order.couponApplied.discountAmount > 0) {
+                        yPosition += 8;
+                        doc.setTextColor(59, 130, 246); // Blue color
+                        doc.text(`Coupon (${order.couponApplied.couponCode}):`, 150, yPosition);
+                        doc.text(
+                                `-${formatAmount(order.couponApplied.discountAmount)}`,
+                                175,
+                                yPosition
+                        );
+                        doc.setTextColor(0, 0, 0);
+                }
 
 		// Line separator for total
 		yPosition += 10;

--- a/lib/invoicePDF.js
+++ b/lib/invoicePDF.js
@@ -1257,19 +1257,27 @@ const InvoiceDocument = ({ order }) => {
 							</Text>
 						</View>
 					)}
-					{order.discount > 0 && (
-						<View style={styles.totalRow}>
-							<Text>Discount:</Text>
-							<Text style={styles.alignRight}>
-								-{formatCurrency(order.discount)}
-							</Text>
-						</View>
-					)}
-					<View style={[styles.totalRow, styles.grandTotal]}>
-						<Text>Total Amount:</Text>
-						<Text style={styles.alignRight}>
-							{formatCurrency(order.totalAmount)}
-						</Text>
+                                        {order.discount > 0 && (
+                                                <View style={styles.totalRow}>
+                                                        <Text>Discount:</Text>
+                                                        <Text style={styles.alignRight}>
+                                                                -{formatCurrency(order.discount)}
+                                                        </Text>
+                                                </View>
+                                        )}
+                                        {order.couponApplied && order.couponApplied.discountAmount > 0 && (
+                                                <View style={styles.totalRow}>
+                                                        <Text>{`Coupon (${order.couponApplied.couponCode}):`}</Text>
+                                                        <Text style={styles.alignRight}>
+                                                                -{formatCurrency(order.couponApplied.discountAmount)}
+                                                        </Text>
+                                                </View>
+                                        )}
+                                        <View style={[styles.totalRow, styles.grandTotal]}>
+                                                <Text>Total Amount:</Text>
+                                                <Text style={styles.alignRight}>
+                                                        {formatCurrency(order.totalAmount)}
+                                                </Text>
 					</View>
 				</View>
 

--- a/model/Promocode.js
+++ b/model/Promocode.js
@@ -1,14 +1,15 @@
 import mongoose from "mongoose";
 
 const PromocodeSchema = new mongoose.Schema({
-	name: { type: String, required: true },
-	code: { type: String, unique: true, required: true, sparse: true }, // Unique code for the promocode - 8 characters (Alphanumeric)
-	discount: { type: Number, required: true, min: 0, max: 100 }, // Percentage discount
-	published: { type: Boolean, default: true },
-	status: { type: String, default: "Active" }, // Active, Inactive
+        name: { type: String, required: true },
+        code: { type: String, unique: true, required: true, sparse: true }, // Unique code for the promocode - 8 characters (Alphanumeric)
+        discount: { type: Number, required: true, min: 0, max: 100 }, // Percentage discount
+        published: { type: Boolean, default: true },
+        recommended: { type: Boolean, default: false },
+        status: { type: String, default: "Active" }, // Active, Inactive
 
-	startDate: { type: Date, required: true },
-	endDate: { type: Date, required: true },
+        startDate: { type: Date, required: true },
+        endDate: { type: Date, required: true },
 });
 
 export default mongoose.models.Promocode ||


### PR DESCRIPTION
## Summary
- add a recommended toggle to coupons, persist the flag through the schema and admin APIs, and expose it in the coupons table and forms
- surface recommended coupons to buyers in the cart and checkout order summaries with direct apply actions and clearer discount messaging
- display applied coupon details across buyer order success views and generated invoices

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*
- npx eslint .

------
https://chatgpt.com/codex/tasks/task_e_68d134bd1418832e841462739a69fce3