### PR TITLE
Simplify product feature capture in product popups

### DIFF
--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -34,7 +34,7 @@ const NO_SUBCATEGORY_VALUE = "__no_subcategory__"
 export function AddProductPopup({ open, onOpenChange }) {
   const { addProduct } = useAdminProductStore()
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [features, setFeatures] = useState([{ title: "", description: "" }])
+  const [features, setFeatures] = useState([""])
   const [categories, setCategories] = useState([])
   const [sellers, setSellers] = useState([])
   const [loadingSellers, setLoadingSellers] = useState(false)
@@ -105,6 +105,11 @@ export function AddProductPopup({ open, onOpenChange }) {
     setIsSubmitting(true)
 
     try {
+      const formattedFeatures = features
+        .map((feature) => feature.trim())
+        .filter((feature) => feature.length > 0)
+        .map((feature) => ({ title: feature, description: feature }))
+
       const productData = {
         title: formData.title,
         description: formData.description,
@@ -127,7 +132,7 @@ export function AddProductPopup({ open, onOpenChange }) {
         colour: formData.colour,
         material: formData.material,
         size: formData.size,
-        features: features.filter((f) => f.title && f.description),
+        features: formattedFeatures,
         sellerId: formData.sellerId,
       }
 
@@ -169,20 +174,20 @@ export function AddProductPopup({ open, onOpenChange }) {
       size: "",
       sellerId: "",
     })
-    setFeatures([{ title: "", description: "" }])
+    setFeatures([""])
   }
 
   const addFeature = () => {
-    setFeatures([...features, { title: "", description: "" }])
+    setFeatures([...features, ""])
   }
 
   const removeFeature = (index) => {
     setFeatures(features.filter((_, i) => i !== index))
   }
 
-  const updateFeature = (index, field, value) => {
+  const updateFeature = (index, value) => {
     const updatedFeatures = [...features]
-    updatedFeatures[index][field] = value
+    updatedFeatures[index] = value
     setFeatures(updatedFeatures)
   }
 
@@ -566,19 +571,13 @@ export function AddProductPopup({ open, onOpenChange }) {
               <div className="space-y-3">
                 {features.map((feature, index) => (
                   <div key={index} className="flex gap-3 items-start">
-                    <Input
-                      name="featureTitle"
-                      placeholder="Feature title"
-                      value={feature.title}
-                      onChange={(e) => updateFeature(index, "title", e.target.value)}
-                      className="flex-1"
-                    />
-                    <Input
-                      name="featureDescription"
+                    <Textarea
+                      name={`feature-${index}`}
                       placeholder="Feature description"
-                      value={feature.description}
-                      onChange={(e) => updateFeature(index, "description", e.target.value)}
+                      value={feature}
+                      onChange={(e) => updateFeature(index, e.target.value)}
                       className="flex-1"
+                      rows={2}
                     />
                     {features.length > 1 && (
                       <Button type="button" variant="outline" size="icon" onClick={() => removeFeature(index)}>

--- a/components/AdminPanel/Popups/UpdateProductPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateProductPopup.jsx
@@ -38,9 +38,9 @@ const productTypes = [
 const NO_SUBCATEGORY_VALUE = "__no_subcategory__";
 
 export function UpdateProductPopup({ open, onOpenChange, product }) {
-	const { updateProduct } = useAdminProductStore();
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [features, setFeatures] = useState([{ title: "", description: "" }]);
+        const { updateProduct } = useAdminProductStore();
+        const [isSubmitting, setIsSubmitting] = useState(false);
+        const [features, setFeatures] = useState([""]);
 	const [categories, setCategories] = useState([]);
 	const [sellers, setSellers] = useState([]);
 	const [loadingSellers, setLoadingSellers] = useState(false);
@@ -172,13 +172,19 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 
 			convertImages();
 
-			setFeatures(
-				product.features?.length > 0
-					? product.features
-					: [{ title: "", description: "" }]
-			);
-		}
-	}, [product]);
+                        const mappedFeatures =
+                                product.features?.length > 0
+                                        ? product.features.map(
+                                                  (feature) =>
+                                                          feature?.description?.trim() || feature?.title?.trim() || ""
+                                          )
+                                        : [""];
+
+                        const sanitizedFeatures = mappedFeatures.filter((feature) => feature.length > 0);
+
+                        setFeatures(sanitizedFeatures.length > 0 ? sanitizedFeatures : [""]);
+                }
+        }, [product]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -194,23 +200,28 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 
 		setIsSubmitting(true);
 
-		try {
-			// Prepare the update data similar to addProduct
-			const updateData = {
-				title: formData.title,
-				description: formData.description,
-				longDescription: formData.longDescription || formData.description,
-				category: formData.category,
-				subCategory: formData.subCategory,
+                try {
+                        const formattedFeatures = features
+                                .map((feature) => feature.trim())
+                                .filter((feature) => feature.length > 0)
+                                .map((feature) => ({ title: feature, description: feature }));
+
+                        // Prepare the update data similar to addProduct
+                        const updateData = {
+                                title: formData.title,
+                                description: formData.description,
+                                longDescription: formData.longDescription || formData.description,
+                                category: formData.category,
+                                subCategory: formData.subCategory,
 				price: Number.parseFloat(formData.price),
 				salePrice: formData.salePrice
 					? Number.parseFloat(formData.salePrice)
 					: 0,
-				stocks: Number.parseInt(formData.stocks),
-				discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
-				type: formData.type,
-				published: formData.published,
-				features: features.filter((f) => f.title && f.description),
+                                stocks: Number.parseInt(formData.stocks),
+                                discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
+                                type: formData.type,
+                                published: formData.published,
+                                features: formattedFeatures,
 				images: formData.images, // Pass the base64 images array
 				hsnCode: formData.hsnCode,
 				brand: formData.brand,
@@ -237,17 +248,17 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 		}
 	};
 
-	const addFeature = () => {
-		setFeatures([...features, { title: "", description: "" }]);
-	};
+        const addFeature = () => {
+                setFeatures([...features, ""]);
+        };
 
-	const removeFeature = (index) => {
-		setFeatures(features.filter((_, i) => i !== index));
-	};
+        const removeFeature = (index) => {
+                setFeatures(features.filter((_, i) => i !== index));
+        };
 
-        const updateFeature = (index, field, value) => {
+        const updateFeature = (index, value) => {
                 const updatedFeatures = [...features];
-                updatedFeatures[index][field] = value;
+                updatedFeatures[index] = value;
                 setFeatures(updatedFeatures);
         };
 
@@ -701,41 +712,31 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 									Add Feature
 								</Button>
 							</div>
-							<div className="space-y-3">
-								{features.map((feature, index) => (
-									<div key={index} className="flex gap-3 items-start">
-                                                                                <Input
-                                                                                        name="featureTitle"
-                                                                                        placeholder="Feature title"
-											value={feature.title}
-											onChange={(e) =>
-												updateFeature(index, "title", e.target.value)
-											}
-											className="flex-1"
-										/>
-                                                                                <Input
-                                                                                        name="featureDescription"
+                                                        <div className="space-y-3">
+                                                                {features.map((feature, index) => (
+                                                                        <div key={index} className="flex gap-3 items-start">
+                                                                                <Textarea
+                                                                                        name={`feature-${index}`}
                                                                                         placeholder="Feature description"
-											value={feature.description}
-											onChange={(e) =>
-												updateFeature(index, "description", e.target.value)
-											}
-											className="flex-1"
-										/>
-										{features.length > 1 && (
-											<Button
-												type="button"
-												variant="outline"
-												size="icon"
-												onClick={() => removeFeature(index)}
-											>
-												<X className="w-4 h-4" />
-											</Button>
-										)}
-									</div>
-								))}
-							</div>
-						</div>
+                                                                                        value={feature}
+                                                                                        onChange={(e) => updateFeature(index, e.target.value)}
+                                                                                        className="flex-1"
+                                                                                        rows={2}
+                                                                                />
+                                                                                {features.length > 1 && (
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                size="icon"
+                                                                                                onClick={() => removeFeature(index)}
+                                                                                        >
+                                                                                                <X className="w-4 h-4" />
+                                                                                        </Button>
+                                                                                )}
+                                                                        </div>
+                                                                ))}
+                                                        </div>
+                                                </div>
 
 						{/* Published Toggle */}
 						<div className="flex items-center justify-between">

--- a/components/SellerPanel/Products/AddProductPopup.jsx
+++ b/components/SellerPanel/Products/AddProductPopup.jsx
@@ -46,9 +46,9 @@ const productTypes = [
 ];
 
 export function AddProductPopup({ open, onOpenChange }) {
-	const { addProduct, categories, fetchCategories } = useSellerProductStore();
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [features, setFeatures] = useState([{ title: "", description: "" }]);
+        const { addProduct, categories, fetchCategories } = useSellerProductStore();
+        const [isSubmitting, setIsSubmitting] = useState(false);
+        const [features, setFeatures] = useState([""]);
 	const [selectedCategory, setSelectedCategory] = useState(null);
 
 	const [formData, setFormData] = useState({
@@ -101,21 +101,26 @@ export function AddProductPopup({ open, onOpenChange }) {
                 setIsSubmitting(true);
 
 		try {
-			// Prepare product data with proper types
-			const productData = {
-				title: formData.title,
-				description: formData.description,
-				longDescription: formData.longDescription || formData.description,
-				category: formData.category,
-				price: Number.parseFloat(formData.price),
+                        const formattedFeatures = features
+                                .map((feature) => feature.trim())
+                                .filter((feature) => feature.length > 0)
+                                .map((feature) => ({ title: feature, description: feature }));
+
+                        // Prepare product data with proper types
+                        const productData = {
+                                title: formData.title,
+                                description: formData.description,
+                                longDescription: formData.longDescription || formData.description,
+                                category: formData.category,
+                                price: Number.parseFloat(formData.price),
 				salePrice: formData.salePrice
 					? Number.parseFloat(formData.salePrice)
 					: 0,
 				stocks: Number.parseInt(formData.stocks),
-				discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
-				type: formData.type,
-				published: formData.published,
-				features: features.filter((f) => f.title && f.description),
+                                discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
+                                type: formData.type,
+                                published: formData.published,
+                                features: formattedFeatures,
 				images: formData.images,
 				subCategory: formData.subCategory,
 				hsnCode: formData.hsnCode,
@@ -170,22 +175,22 @@ export function AddProductPopup({ open, onOpenChange }) {
 			material: "",
 			size: "",
 		});
-		setFeatures([{ title: "", description: "" }]);
-	};
+                setFeatures([""]);
+        };
 
-	const addFeature = () => {
-		setFeatures([...features, { title: "", description: "" }]);
-	};
+        const addFeature = () => {
+                setFeatures([...features, ""]);
+        };
 
-	const removeFeature = (index) => {
-		setFeatures(features.filter((_, i) => i !== index));
-	};
+        const removeFeature = (index) => {
+                setFeatures(features.filter((_, i) => i !== index));
+        };
 
-	const updateFeature = (index, field, value) => {
-		const updatedFeatures = [...features];
-		updatedFeatures[index][field] = value;
-		setFeatures(updatedFeatures);
-	};
+        const updateFeature = (index, value) => {
+                const updatedFeatures = [...features];
+                updatedFeatures[index] = value;
+                setFeatures(updatedFeatures);
+        };
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -541,43 +546,32 @@ export function AddProductPopup({ open, onOpenChange }) {
 									Add Feature
 								</Button>
 							</div>
-							<div className="space-y-3">
-								{features.map((feature, index) => (
-									<div key={index} className="flex gap-3 items-start">
-                                                                                <Input
-                                                                                        id={`feature-title-${index}`}
-                                                                                        name="featureTitle"
-                                                                                        placeholder="Feature title"
-                                                                                        value={feature.title}
-                                                                                        onChange={(e) =>
-                                                                                                updateFeature(index, "title", e.target.value)
-                                                                                        }
-                                                                                        className="flex-1"
-                                                                                />
-                                                                                <Input
-                                                                                        id={`feature-description-${index}`}
+                                                        <div className="space-y-3">
+                                                                {features.map((feature, index) => (
+                                                                        <div key={index} className="flex gap-3 items-start">
+                                                                                <Textarea
+                                                                                        id={`feature-${index}`}
                                                                                         name="featureDescription"
                                                                                         placeholder="Feature description"
-                                                                                        value={feature.description}
-                                                                                        onChange={(e) =>
-                                                                                                updateFeature(index, "description", e.target.value)
-                                                                                        }
+                                                                                        value={feature}
+                                                                                        onChange={(e) => updateFeature(index, e.target.value)}
                                                                                         className="flex-1"
+                                                                                        rows={2}
                                                                                 />
-										{features.length > 1 && (
-											<Button
-												type="button"
-												variant="outline"
-												size="icon"
-												onClick={() => removeFeature(index)}
-											>
-												<X className="w-4 h-4" />
-											</Button>
-										)}
-									</div>
-								))}
-							</div>
-						</div>
+                                                                                {features.length > 1 && (
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                size="icon"
+                                                                                                onClick={() => removeFeature(index)}
+                                                                                        >
+                                                                                                <X className="w-4 h-4" />
+                                                                                        </Button>
+                                                                                )}
+                                                                        </div>
+                                                                ))}
+                                                        </div>
+                                                </div>
 
 						<div className="flex items-center justify-between">
 							<div>

--- a/components/SellerPanel/Products/UpdateProductPopup.jsx
+++ b/components/SellerPanel/Products/UpdateProductPopup.jsx
@@ -46,10 +46,10 @@ const productTypes = [
 ];
 
 export function UpdateProductPopup({ open, onOpenChange, product }) {
-	const { updateProduct, categories, fetchCategories } =
-		useSellerProductStore();
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [features, setFeatures] = useState([{ title: "", description: "" }]);
+        const { updateProduct, categories, fetchCategories } =
+                useSellerProductStore();
+        const [isSubmitting, setIsSubmitting] = useState(false);
+        const [features, setFeatures] = useState([""]);
 	const [selectedCategory, setSelectedCategory] = useState(null);
 
 	const [formData, setFormData] = useState({
@@ -154,13 +154,19 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 
 			convertImages();
 
-			setFeatures(
-				product.features?.length > 0
-					? product.features
-					: [{ title: "", description: "" }]
-			);
-		}
-	}, [product]);
+                        const mappedFeatures =
+                                product.features?.length > 0
+                                        ? product.features.map(
+                                                  (feature) =>
+                                                          feature?.description?.trim() || feature?.title?.trim() || ""
+                                          )
+                                        : [""];
+
+                        const sanitizedFeatures = mappedFeatures.filter((feature) => feature.length > 0);
+
+                        setFeatures(sanitizedFeatures.length > 0 ? sanitizedFeatures : [""]);
+                }
+        }, [product]);
 
         const handleSubmit = async (e) => {
                 e.preventDefault();
@@ -172,22 +178,27 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 
                 setIsSubmitting(true);
 
-		try {
-			// Prepare the update data similar to addProduct
-			const updateData = {
-				title: formData.title,
-				description: formData.description,
-				longDescription: formData.longDescription || formData.description,
-				category: formData.category,
-				price: Number.parseFloat(formData.price),
+                try {
+                        const formattedFeatures = features
+                                .map((feature) => feature.trim())
+                                .filter((feature) => feature.length > 0)
+                                .map((feature) => ({ title: feature, description: feature }));
+
+                        // Prepare the update data similar to addProduct
+                        const updateData = {
+                                title: formData.title,
+                                description: formData.description,
+                                longDescription: formData.longDescription || formData.description,
+                                category: formData.category,
+                                price: Number.parseFloat(formData.price),
 				salePrice: formData.salePrice
 					? Number.parseFloat(formData.salePrice)
 					: 0,
 				stocks: Number.parseInt(formData.stocks),
-				discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
-				type: formData.type,
-				published: formData.published,
-				features: features.filter((f) => f.title && f.description),
+                                discount: formData.discount ? Number.parseFloat(formData.discount) : 0,
+                                type: formData.type,
+                                published: formData.published,
+                                features: formattedFeatures,
 				images: formData.images, // Pass the base64 images array
 				subCategory: formData.subCategory,
 				hsnCode: formData.hsnCode,
@@ -214,19 +225,19 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 		}
 	};
 
-	const addFeature = () => {
-		setFeatures([...features, { title: "", description: "" }]);
-	};
+        const addFeature = () => {
+            setFeatures([...features, ""]);
+        };
 
-	const removeFeature = (index) => {
-		setFeatures(features.filter((_, i) => i !== index));
-	};
+        const removeFeature = (index) => {
+            setFeatures(features.filter((_, i) => i !== index));
+        };
 
-	const updateFeature = (index, field, value) => {
-		const updatedFeatures = [...features];
-		updatedFeatures[index][field] = value;
-		setFeatures(updatedFeatures);
-	};
+        const updateFeature = (index, value) => {
+                const updatedFeatures = [...features];
+                updatedFeatures[index] = value;
+                setFeatures(updatedFeatures);
+        };
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -595,43 +606,32 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 									Add Feature
 								</Button>
 							</div>
-							<div className="space-y-3">
-								{features.map((feature, index) => (
-									<div key={index} className="flex gap-3 items-start">
-                                                                                <Input
-                                                                                        id={`update-feature-title-${index}`}
-                                                                                        name="featureTitle"
-                                                                                        placeholder="Feature title"
-                                                                                        value={feature.title}
-                                                                                        onChange={(e) =>
-                                                                                                updateFeature(index, "title", e.target.value)
-                                                                                        }
-                                                                                        className="flex-1"
-                                                                                />
-                                                                                <Input
-                                                                                        id={`update-feature-description-${index}`}
+                                                        <div className="space-y-3">
+                                                                {features.map((feature, index) => (
+                                                                        <div key={index} className="flex gap-3 items-start">
+                                                                                <Textarea
+                                                                                        id={`update-feature-${index}`}
                                                                                         name="featureDescription"
                                                                                         placeholder="Feature description"
-                                                                                        value={feature.description}
-                                                                                        onChange={(e) =>
-                                                                                                updateFeature(index, "description", e.target.value)
-                                                                                        }
+                                                                                        value={feature}
+                                                                                        onChange={(e) => updateFeature(index, e.target.value)}
                                                                                         className="flex-1"
+                                                                                        rows={2}
                                                                                 />
-										{features.length > 1 && (
-											<Button
-												type="button"
-												variant="outline"
-												size="icon"
-												onClick={() => removeFeature(index)}
-											>
-												<X className="w-4 h-4" />
-											</Button>
-										)}
-									</div>
-								))}
-							</div>
-						</div>
+                                                                                {features.length > 1 && (
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                size="icon"
+                                                                                                onClick={() => removeFeature(index)}
+                                                                                        >
+                                                                                                <X className="w-4 h-4" />
+                                                                                        </Button>
+                                                                                )}
+                                                                        </div>
+                                                                ))}
+                                                        </div>
+                                                </div>
 
 						<div className="flex items-center justify-between">
 							<div>


### PR DESCRIPTION
## Summary
- replace the duplicate key feature fields in admin add/update product popups with a single textarea and normalize submission data
- mirror the streamlined key feature editing experience in the seller add/update product popups so it matches the product detail view
