### PR TITLE
Fix IGST rate displayed on invoice PDF

### DIFF
--- a/lib/invoicePDF.js
+++ b/lib/invoicePDF.js
@@ -777,16 +777,17 @@
 // export default InvoiceDocument;
 
 import {
-	Document,
-	Page,
-	Text,
-	View,
-	Image,
-	StyleSheet,
-	pdf,
-	Font,
+        Document,
+        Page,
+        Text,
+        View,
+        Image,
+        StyleSheet,
+        pdf,
+        Font,
 } from "@react-pdf/renderer";
 import { companyInfo } from "@/constants/companyInfo.js";
+import { GST_RATE_PERCENT } from "@/lib/utils/gst.js";
 
 // Register a font with the Indian Rupee symbol (₹) using a CDN that
 // supports query strings so React PDF can request only the glyphs it needs.
@@ -807,10 +808,24 @@ Font.register({
 });
 
 const formatCurrency = (value) =>
-	`₹${value.toLocaleString("en-IN", {
-		minimumFractionDigits: 2,
-		maximumFractionDigits: 2,
-	})}`;
+        `₹${value.toLocaleString("en-IN", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+        })}`;
+
+const formatRateValue = (value) => {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+                return "0";
+        }
+
+        const fixed = numeric.toFixed(2);
+        if (fixed.endsWith(".00")) {
+                return fixed.slice(0, -3);
+        }
+
+        return fixed.replace(/(\.[0-9]*[1-9])0+$/, "$1");
+};
 
 const formatDate = (date) => {
 	if (!date) return "N/A";
@@ -975,36 +990,35 @@ const InvoiceDocument = ({ order }) => {
 			? `${companyInfo.website}${companyInfo.logo}`
 			: companyInfo.logo;
 
-	const cgstRate = order.subtotal
-		? (order.gst?.cgst / order.subtotal) * 100
-		: 0;
-	const sgstRate = order.subtotal
-		? (order.gst?.sgst / order.subtotal) * 100
-		: 0;
-	const igstRate = order.subtotal
-		? (order.gst?.igst / order.subtotal) * 100
-		: 0;
+        const rawGstRate = Number(order?.gst?.rate);
+        const gstRate =
+                Number.isFinite(rawGstRate) && rawGstRate > 0
+                        ? rawGstRate
+                        : GST_RATE_PERCENT;
+        const igstRate = gstRate;
+        const cgstRate = gstRate / 2;
+        const sgstRate = gstRate / 2;
 
 	const totalTaxLines = [];
-	if (order.gst?.igst > 0) {
-		totalTaxLines.push({
-			label: `IGST ${igstRate.toFixed(0)}%`,
-			amount: order.gst.igst,
-		});
-	} else {
-		if (order.gst?.cgst > 0) {
-			totalTaxLines.push({
-				label: `CGST ${cgstRate.toFixed(0)}%`,
-				amount: order.gst.cgst,
-			});
-		}
-		if (order.gst?.sgst > 0) {
-			totalTaxLines.push({
-				label: `SGST ${sgstRate.toFixed(0)}%`,
-				amount: order.gst.sgst,
-			});
-		}
-	}
+        if (order.gst?.igst > 0) {
+                totalTaxLines.push({
+                        label: `IGST ${formatRateValue(igstRate)}%`,
+                        amount: order.gst.igst,
+                });
+        } else {
+                if (order.gst?.cgst > 0) {
+                        totalTaxLines.push({
+                                label: `CGST ${formatRateValue(cgstRate)}%`,
+                                amount: order.gst.cgst,
+                        });
+                }
+                if (order.gst?.sgst > 0) {
+                        totalTaxLines.push({
+                                label: `SGST ${formatRateValue(sgstRate)}%`,
+                                amount: order.gst.sgst,
+                        });
+                }
+        }
 
 	const orderDate = order?.orderDate ? new Date(order.orderDate) : null;
 
@@ -1187,17 +1201,17 @@ const InvoiceDocument = ({ order }) => {
 
 						let taxType = "";
 						let taxAmountStr = "";
-						if (igstTotal > 0) {
-							taxType = `IGST ${igstRate.toFixed(0)}%`;
-							taxAmountStr = formatCurrency(productIgst);
-						} else if (cgstTotal > 0 || sgstTotal > 0) {
-							taxType = `CGST ${cgstRate.toFixed(0)}%\nSGST ${sgstRate.toFixed(
-								0
-							)}%`; // <-- single \n
-							taxAmountStr = `${formatCurrency(productCgst)}\n${formatCurrency(
-								productSgst
-							)}`; // <-- single \n
-						}
+                                                if (igstTotal > 0) {
+                                                        taxType = `IGST ${formatRateValue(igstRate)}%`;
+                                                        taxAmountStr = formatCurrency(productIgst);
+                                                } else if (cgstTotal > 0 || sgstTotal > 0) {
+                                                        taxType = `CGST ${formatRateValue(cgstRate)}%\nSGST ${formatRateValue(
+                                                                sgstRate
+                                                        )}%`; // <-- single \n
+                                                        taxAmountStr = `${formatCurrency(productCgst)}\n${formatCurrency(
+                                                                productSgst
+                                                        )}`; // <-- single \n
+                                                }
 
 						const productTax = productCgst + productSgst + productIgst;
 						const amountWithTax = product.totalPrice + productTax;


### PR DESCRIPTION
## Summary
- read the GST rate directly from order data with a default fallback for invoice generation
- format GST percentage labels consistently so IGST, CGST, and SGST percentages render correctly throughout the PDF
