### PR TITLE
Fix category product counts across admin and navigation

### DIFF
--- a/app/api/admin/categories/route.js
+++ b/app/api/admin/categories/route.js
@@ -204,6 +204,7 @@
 // app/api/admin/categories/route.js
 
 import { dbConnect } from "@/lib/dbConnect.js";
+import { attachProductCountsToCategories } from "@/lib/categoryCounts.js";
 import Category from "@/model/Categories.js";
 
 export async function GET(request) {
@@ -240,18 +241,10 @@ export async function GET(request) {
                         .limit(limit)
                         .lean();
 
-                const normalizedCategories = categories.map((category) => ({
-                        ...category,
-                        subCategories: Array.isArray(category.subCategories)
-                                ? category.subCategories.map((sub) => ({
-                                          ...sub,
-                                          published:
-                                                  sub?.published !== undefined
-                                                          ? !!sub.published
-                                                          : true,
-                                  }))
-                                : [],
-                }));
+                const normalizedCategories = await attachProductCountsToCategories(
+                        categories,
+                        { persist: true }
+                );
 
                 const total = await Category.countDocuments(query);
                 const totalPages = Math.ceil(total / limit);

--- a/app/api/categories/route.js
+++ b/app/api/categories/route.js
@@ -1,4 +1,5 @@
 import { dbConnect } from "@/lib/dbConnect.js";
+import { attachProductCountsToCategories } from "@/lib/categoryCounts.js";
 import Category from "@/model/Categories.js";
 
 export async function GET() {
@@ -6,17 +7,22 @@ export async function GET() {
 		await dbConnect();
 
 		// Only published categories
-		const cats = await Category.find({ published: true })
-			.sort({ name: 1 })
-			.lean();
+                const cats = await Category.find({ published: true })
+                        .sort({ name: 1 })
+                        .lean();
 
-		const categories = cats.map((c) => ({
-			_id: c._id,
-			name: c.name,
-			productCount: c.productCount || 0,
-			subCategories: c.subCategories || [],
-			published: true,
-		}));
+                const categoriesWithCounts = await attachProductCountsToCategories(
+                        cats,
+                        { persist: true }
+                );
+
+                const categories = categoriesWithCounts.map((category) => ({
+                        _id: category._id,
+                        name: category.name,
+                        productCount: category.productCount || 0,
+                        subCategories: category.subCategories || [],
+                        published: true,
+                }));
 
 		return Response.json({
 			success: true,

--- a/lib/categoryCounts.js
+++ b/lib/categoryCounts.js
@@ -1,0 +1,149 @@
+import Category from "@/model/Categories.js";
+import Product from "@/model/Product.js";
+
+const normalizeName = (value) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "";
+
+const normalizeSubCategories = (subCategories = []) =>
+        Array.isArray(subCategories)
+                ? subCategories.map((subCategory) => ({
+                              ...subCategory,
+                              published:
+                                      subCategory?.published !== undefined
+                                              ? !!subCategory.published
+                                              : true,
+                              productCount: Number(subCategory?.productCount) || 0,
+                      }))
+                : [];
+
+export async function attachProductCountsToCategories(
+        categories,
+        { persist = false } = {}
+) {
+        const safeCategories = Array.isArray(categories)
+                ? categories.map((category) => ({
+                          ...category,
+                          subCategories: normalizeSubCategories(category.subCategories),
+                  }))
+                : [];
+
+        if (safeCategories.length === 0) {
+                return safeCategories;
+        }
+
+        const productCounts = await Product.aggregate([
+                {
+                        $match: {
+                                published: true,
+                                category: { $exists: true, $ne: null, $ne: "" },
+                        },
+                },
+                {
+                        $project: {
+                                category: {
+                                        $toLower: {
+                                                $trim: { input: "$category" },
+                                        },
+                                },
+                                subCategory: {
+                                        $toLower: {
+                                                $trim: {
+                                                        input: { $ifNull: ["$subCategory", ""] },
+                                                },
+                                        },
+                                },
+                        },
+                },
+                {
+                        $group: {
+                                _id: {
+                                        category: "$category",
+                                        subCategory: "$subCategory",
+                                },
+                                count: { $sum: 1 },
+                        },
+                },
+        ]);
+
+        const categoryTotals = new Map();
+        const subCategoryTotals = new Map();
+
+        productCounts.forEach(({ _id, count }) => {
+                const categoryKey = normalizeName(_id?.category);
+                if (!categoryKey) {
+                        return;
+                }
+
+                categoryTotals.set(
+                        categoryKey,
+                        (categoryTotals.get(categoryKey) || 0) + count
+                );
+
+                const subKey = normalizeName(_id?.subCategory);
+                if (!subKey) {
+                        return;
+                }
+
+                if (!subCategoryTotals.has(categoryKey)) {
+                        subCategoryTotals.set(categoryKey, new Map());
+                }
+
+                const subMap = subCategoryTotals.get(categoryKey);
+                subMap.set(subKey, (subMap.get(subKey) || 0) + count);
+        });
+
+        const categoriesWithCounts = safeCategories.map((category) => {
+                const normalizedCategoryName = normalizeName(category.name);
+                const productCount = categoryTotals.get(normalizedCategoryName) || 0;
+
+                const subCategories = category.subCategories.map((subCategory) => {
+                        const normalizedSubName = normalizeName(subCategory.name);
+                        const subCategoryCount =
+                                subCategoryTotals.get(normalizedCategoryName)?.get(
+                                        normalizedSubName
+                                ) || 0;
+
+                        return {
+                                ...subCategory,
+                                productCount: subCategoryCount,
+                        };
+                });
+
+                return {
+                        ...category,
+                        productCount,
+                        subCategories,
+                };
+        });
+
+        if (persist) {
+                const operations = categoriesWithCounts
+                        .map((category, index) => {
+                                const sourceCategory = categories[index];
+                                const id = sourceCategory?._id;
+
+                                if (!id) {
+                                        return null;
+                                }
+
+                                return {
+                                        updateOne: {
+                                                filter: { _id: id },
+                                                update: {
+                                                        $set: {
+                                                                productCount: category.productCount,
+                                                                subCategories: category.subCategories,
+                                                        },
+                                                },
+                                        },
+                                };
+                        })
+                        .filter(Boolean);
+
+                if (operations.length > 0) {
+                        await Category.bulkWrite(operations);
+                }
+        }
+
+        return categoriesWithCounts;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper that aggregates published product totals for each category and sub-category and optionally persists the counts
- use the shared helper in the admin categories endpoint so the management table shows accurate product totals
- update the public categories endpoint to return the same computed counts for the navigation menu
