### PR TITLE
Fix category product counts to match subcategory slugs

### DIFF
--- a/lib/categoryCounts.js
+++ b/lib/categoryCounts.js
@@ -1,19 +1,19 @@
 import Category from "@/model/Categories.js";
 import Product from "@/model/Product.js";
+import { ensureSlug } from "@/lib/slugify.js";
 
-const normalizeName = (value) =>
-        typeof value === "string" ? value.trim().toLowerCase() : "";
+const normalizeName = (value) => ensureSlug(value || "");
 
 const normalizeSubCategories = (subCategories = []) =>
         Array.isArray(subCategories)
                 ? subCategories.map((subCategory) => ({
-                              ...subCategory,
-                              published:
-                                      subCategory?.published !== undefined
-                                              ? !!subCategory.published
-                                              : true,
-                              productCount: Number(subCategory?.productCount) || 0,
-                      }))
+                          ...subCategory,
+                          published:
+                                  subCategory?.published !== undefined
+                                          ? !!subCategory.published
+                                          : true,
+                          productCount: Number(subCategory?.productCount) || 0,
+                  }))
                 : [];
 
 export async function attachProductCountsToCategories(
@@ -93,11 +93,15 @@ export async function attachProductCountsToCategories(
         });
 
         const categoriesWithCounts = safeCategories.map((category) => {
-                const normalizedCategoryName = normalizeName(category.name);
+                const normalizedCategoryName = normalizeName(
+                        category.slug || category.name
+                );
                 const productCount = categoryTotals.get(normalizedCategoryName) || 0;
 
                 const subCategories = category.subCategories.map((subCategory) => {
-                        const normalizedSubName = normalizeName(subCategory.name);
+                        const normalizedSubName = normalizeName(
+                                subCategory.slug || subCategory.name
+                        );
                         const subCategoryCount =
                                 subCategoryTotals.get(normalizedCategoryName)?.get(
                                         normalizedSubName


### PR DESCRIPTION
## Summary
- normalize category and subcategory names to slugs when counting products
- ensure persisted category data retains accurate product totals when products store slugs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78a7b2c30832e99527bf87e237ff1