### PR TITLE
Improve product filtering slug normalization

### DIFF
--- a/app/api/products/[id]/route.js
+++ b/app/api/products/[id]/route.js
@@ -18,8 +18,25 @@ const createNameVariants = (value = "") => {
 
         const hyphenated = trimmed.replace(/\s+/g, "-");
         const spaced = trimmed.replace(/-/g, " ");
+        const withoutSpacesOrHyphens = trimmed.replace(/[\s-]+/g, "");
 
-        return Array.from(new Set([trimmed, hyphenated, spaced]));
+        const ampersandReplaced = trimmed.replace(/&/g, "and");
+        const ampHyphenated = ampersandReplaced.replace(/\s+/g, "-");
+        const ampSpaced = ampersandReplaced.replace(/-/g, " ");
+        const ampWithoutSpacesOrHyphens = ampersandReplaced.replace(/[\s-]+/g, "");
+
+        return Array.from(
+                new Set([
+                        trimmed,
+                        hyphenated,
+                        spaced,
+                        withoutSpacesOrHyphens,
+                        ampersandReplaced,
+                        ampHyphenated,
+                        ampSpaced,
+                        ampWithoutSpacesOrHyphens,
+                ])
+        );
 };
 
 const buildRegexArray = (values = []) => {

--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -42,22 +42,39 @@ export async function GET(request) {
 		const escapeRegex = (value = "") =>
 			value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-		const createNameVariants = (value = "") => {
-			if (!value) {
-				return [];
-			}
+                const createNameVariants = (value = "") => {
+                        if (!value) {
+                                return [];
+                        }
 
-			const trimmed = value.trim();
+                        const trimmed = value.toString().trim();
 
-			if (!trimmed) {
-				return [];
-			}
+                        if (!trimmed) {
+                                return [];
+                        }
 
-			const hyphenated = trimmed.replace(/\s+/g, "-");
-			const spaced = trimmed.replace(/-/g, " ");
+                        const hyphenated = trimmed.replace(/\s+/g, "-");
+                        const spaced = trimmed.replace(/-/g, " ");
+                        const withoutSpacesOrHyphens = trimmed.replace(/[\s-]+/g, "");
 
-			return Array.from(new Set([trimmed, hyphenated, spaced]));
-		};
+                        const ampersandReplaced = trimmed.replace(/&/g, "and");
+                        const ampHyphenated = ampersandReplaced.replace(/\s+/g, "-");
+                        const ampSpaced = ampersandReplaced.replace(/-/g, " ");
+                        const ampWithoutSpacesOrHyphens = ampersandReplaced.replace(/[\s-]+/g, "");
+
+                        return Array.from(
+                                new Set([
+                                        trimmed,
+                                        hyphenated,
+                                        spaced,
+                                        withoutSpacesOrHyphens,
+                                        ampersandReplaced,
+                                        ampHyphenated,
+                                        ampSpaced,
+                                        ampWithoutSpacesOrHyphens,
+                                ])
+                        );
+                };
 
 		const buildRegexArray = (values = []) => {
 			const uniqueValues = Array.from(


### PR DESCRIPTION
## Summary
- expand the product query name normalization to generate additional variations that cover hyphenless and ampersand-normalised forms when filtering by subcategory or category
- apply the same expanded normalization to related product lookups so product detail pages benefit from the broader matching

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68d790588a54832e92a64549f0bdb427