### PR TITLE
Improve category and subcategory matching

### DIFF
--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -76,19 +76,153 @@ export async function GET(request) {
                         );
                 };
 
-		const buildRegexArray = (values = []) => {
-			const uniqueValues = Array.from(
-				new Set(
-					values
-						.map((value) => value?.toString().trim())
-						.filter((value) => value && value.length > 0)
-				)
-			);
+                const buildRegexArray = (values = []) => {
+                        const uniqueValues = Array.from(
+                                new Set(
+                                        values
+                                                .map((value) =>
+                                                        value?.toString().trim()
+                                                )
+                                                .filter((value) => value && value.length > 0)
+                                )
+                        );
 
-			return uniqueValues.map(
-				(value) => new RegExp(`^${escapeRegex(value)}$`, "i")
-			);
-		};
+                        return uniqueValues.map(
+                                (value) => new RegExp(`^${escapeRegex(value)}$`, "i")
+                        );
+                };
+
+                const appendValueAndVariants = (set, rawValue) => {
+                        if (rawValue === undefined || rawValue === null) {
+                                return;
+                        }
+
+                        const stringValue =
+                                typeof rawValue === "string"
+                                        ? rawValue
+                                        : rawValue?.toString?.() || "";
+
+                        const trimmed = stringValue.trim();
+
+                        if (!trimmed) {
+                                return;
+                        }
+
+                        const maybeAdd = (value) => {
+                                if (!value && value !== 0) {
+                                        return;
+                                }
+
+                                const valueString =
+                                        typeof value === "string"
+                                                ? value
+                                                : value?.toString?.() || "";
+
+                                const valueTrimmed = valueString.trim();
+
+                                if (valueTrimmed) {
+                                        set.add(valueTrimmed);
+                                }
+                        };
+
+                        maybeAdd(trimmed);
+
+                        const normalized = ensureSlug(trimmed);
+
+                        if (normalized && normalized !== trimmed) {
+                                set.add(normalized);
+                        }
+
+                        createNameVariants(trimmed).forEach((variant) => {
+                                const variantTrimmed = variant.trim();
+
+                                if (!variantTrimmed) {
+                                        return;
+                                }
+
+                                set.add(variantTrimmed);
+
+                                const variantNormalized = ensureSlug(variantTrimmed);
+
+                                if (
+                                        variantNormalized &&
+                                        variantNormalized !== variantTrimmed &&
+                                        variantNormalized !== normalized
+                                ) {
+                                        set.add(variantNormalized);
+                                }
+                        });
+                };
+
+                const doesIdentifierMatch = (
+                        identifier,
+                        normalizedIdentifier,
+                        candidatesSet
+                ) => {
+                        if (identifier === undefined || identifier === null) {
+                                return false;
+                        }
+
+                        const identifierString =
+                                typeof identifier === "string"
+                                        ? identifier
+                                        : identifier?.toString?.() || "";
+
+                        const trimmedIdentifier = identifierString.trim();
+
+                        if (!trimmedIdentifier) {
+                                return false;
+                        }
+
+                        const lowerIdentifier = trimmedIdentifier.toLowerCase();
+
+                        for (const candidate of candidatesSet) {
+                                const candidateString =
+                                        typeof candidate === "string"
+                                                ? candidate
+                                                : candidate?.toString?.();
+
+                                if (!candidateString) {
+                                        continue;
+                                }
+
+                                const trimmedCandidate = candidateString.trim();
+
+                                if (!trimmedCandidate) {
+                                        continue;
+                                }
+
+                                if (trimmedCandidate === trimmedIdentifier) {
+                                        return true;
+                                }
+
+                                if (trimmedCandidate.toLowerCase() === lowerIdentifier) {
+                                        return true;
+                                }
+
+                                if (
+                                        normalizedIdentifier &&
+                                        ensureSlug(trimmedCandidate) === normalizedIdentifier
+                                ) {
+                                        return true;
+                                }
+                        }
+
+                        return false;
+                };
+
+                let categoriesCache = null;
+
+                const getPublishedCategories = async () => {
+                        if (!categoriesCache) {
+                                categoriesCache = await Categories.find(
+                                        { published: true },
+                                        { name: 1, subCategories: 1 }
+                                ).lean();
+                        }
+
+                        return categoriesCache;
+                };
 
 		const ensureAndConditions = (queryObject) => {
 			if (!queryObject.$and) {
@@ -101,46 +235,75 @@ export async function GET(request) {
 		// Build query
 		const query = { published: true };
 
+                let matchedCategoryValuesFromSubCategory = new Set();
+
                 if (subCategoryParam) {
                         const normalizedSubCategory = ensureSlug(subCategoryParam);
+                        const possibleSubCategoryValues = new Set();
 
-                        const possibleSubCategoryValues = new Set([
-                                subCategoryParam,
-                                ...createNameVariants(subCategoryParam),
-                        ]);
+                        appendValueAndVariants(possibleSubCategoryValues, subCategoryParam);
 
-                        if (normalizedSubCategory) {
-                                const categoriesWithSubCategories = await Categories.find(
-                                        { published: true },
-                                        { name: 1, subCategories: 1 }
-                                ).lean();
+                        if (
+                                normalizedSubCategory &&
+                                normalizedSubCategory !== subCategoryParam
+                        ) {
+                                appendValueAndVariants(
+                                        possibleSubCategoryValues,
+                                        normalizedSubCategory
+                                );
+                        }
 
-                                categoriesWithSubCategories.forEach((category) => {
-                                        category.subCategories?.forEach((subCategory) => {
-                                                const slugFromSubCategory = ensureSlug(
-                                                        subCategory.slug || subCategory.name
+                        const categoriesWithSubCategories =
+                                await getPublishedCategories();
+
+                        categoriesWithSubCategories.forEach((categoryDocument) => {
+                                categoryDocument.subCategories?.forEach((subCategory) => {
+                                        const candidateValues = new Set();
+
+                                        appendValueAndVariants(
+                                                candidateValues,
+                                                subCategory?.name
+                                        );
+
+                                        if (subCategory?.slug) {
+                                                appendValueAndVariants(
+                                                        candidateValues,
+                                                        subCategory.slug
+                                                );
+                                        }
+
+                                        if (subCategory?._id) {
+                                                appendValueAndVariants(
+                                                        candidateValues,
+                                                        subCategory._id.toString()
+                                                );
+                                        }
+
+                                        if (
+                                                doesIdentifierMatch(
+                                                        subCategoryParam,
+                                                        normalizedSubCategory,
+                                                        candidateValues
+                                                )
+                                        ) {
+                                                candidateValues.forEach((value) => {
+                                                        possibleSubCategoryValues.add(value);
+                                                });
+
+                                                appendValueAndVariants(
+                                                        matchedCategoryValuesFromSubCategory,
+                                                        categoryDocument.name
                                                 );
 
-                                                if (slugFromSubCategory === normalizedSubCategory) {
-                                                        const subCategoryName = subCategory.name || "";
-                                                        const subCategorySlug = subCategory.slug || subCategoryName;
-
-                                                        possibleSubCategoryValues.add(subCategoryName);
-                                                        possibleSubCategoryValues.add(subCategorySlug);
-                                                        possibleSubCategoryValues.add(
-                                                                subCategoryName
-                                                                        .replace(/&/g, "and")
-                                                                        .replace(/\s+/g, "-")
-                                                        );
-                                                        possibleSubCategoryValues.add(
-                                                                subCategoryName
-                                                                        .replace(/&/g, "and")
-                                                                        .replace(/-/g, " ")
+                                                if (categoryDocument.slug) {
+                                                        appendValueAndVariants(
+                                                                matchedCategoryValuesFromSubCategory,
+                                                                categoryDocument.slug
                                                         );
                                                 }
-                                        });
+                                        }
                                 });
-                        }
+                        });
 
                         const subCategoryRegexes = buildRegexArray(
                                 Array.from(possibleSubCategoryValues)
@@ -153,79 +316,146 @@ export async function GET(request) {
                         } else {
                                 query.subCategory = subCategoryParam;
                         }
-		} else if (category && category !== "all") {
-			const categoryVariantsToCheck = Array.from(
-				new Set([category, ...createNameVariants(category)])
-			);
 
-			let categoryDocument = null;
+                        if (matchedCategoryValuesFromSubCategory.size > 0) {
+                                const categoryRegexesFromSubCategory = buildRegexArray(
+                                        Array.from(matchedCategoryValuesFromSubCategory)
+                                );
 
-			for (const variant of categoryVariantsToCheck) {
-				// Try to find a matching category document using different variants
-				// to handle inputs with spaces, hyphens, or different casing.
-				categoryDocument = await Categories.findOne({
-					published: true,
-					name: new RegExp(`^${escapeRegex(variant)}$`, "i"),
-				}).lean();
+                                if (categoryRegexesFromSubCategory.length > 0) {
+                                        ensureAndConditions(query).push({
+                                                category: { $in: categoryRegexesFromSubCategory },
+                                        });
+                                }
+                        }
+                }
 
-				if (categoryDocument) {
-					break;
-				}
-			}
+                if (category && category !== "all") {
+                        const categoryVariantsToCheck = Array.from(
+                                new Set([category, ...createNameVariants(category)])
+                        );
 
-			if (categoryDocument) {
-				const orConditions = [];
+                        const normalizedCategory = ensureSlug(category);
+                        const categoriesWithSubCategories = await getPublishedCategories();
 
-				const categoryRegexes = buildRegexArray([
-					categoryDocument.name,
-					...createNameVariants(categoryDocument.name),
-					...categoryVariantsToCheck,
-				]);
+                        let categoryDocument = null;
+                        let matchedCategoryCandidateValues = new Set();
 
-				if (categoryRegexes.length > 0) {
-					orConditions.push({ category: { $in: categoryRegexes } });
-				}
+                        for (const categoryEntry of categoriesWithSubCategories) {
+                                const candidateValues = new Set();
 
-				const subCategoryNames =
-					categoryDocument.subCategories?.map((sub) => sub.name) || [];
+                                appendValueAndVariants(
+                                        candidateValues,
+                                        categoryEntry?.name
+                                );
 
-				if (subCategoryNames.length > 0) {
-					const subCategoryRegexes = buildRegexArray(
-						subCategoryNames.flatMap((name) => [
-							name,
-							...createNameVariants(name),
-						])
-					);
+                                if (categoryEntry?.slug) {
+                                        appendValueAndVariants(
+                                                candidateValues,
+                                                categoryEntry.slug
+                                        );
+                                }
 
-					if (subCategoryRegexes.length > 0) {
-						orConditions.push({
-							subCategory: { $in: subCategoryRegexes },
-						});
-					}
-				}
+                                if (categoryEntry?._id) {
+                                        candidateValues.add(categoryEntry._id.toString());
+                                }
 
-				if (orConditions.length > 0) {
-					ensureAndConditions(query).push({ $or: orConditions });
-				} else if (categoryDocument.name) {
-					query.category = categoryDocument.name;
-				} else {
-					query.category = category;
-				}
-			} else {
-				const fallbackCategoryRegexes = buildRegexArray([
-					category,
-					...createNameVariants(category),
-				]);
+                                const directMatch = doesIdentifierMatch(
+                                        category,
+                                        normalizedCategory,
+                                        candidateValues
+                                );
 
-				if (fallbackCategoryRegexes.length > 0) {
-					ensureAndConditions(query).push({
-						category: { $in: fallbackCategoryRegexes },
-					});
-				} else {
-					query.category = category;
-				}
-			}
-		}
+                                const variantMatch = categoryVariantsToCheck.some((variant) =>
+                                        doesIdentifierMatch(
+                                                variant,
+                                                ensureSlug(variant),
+                                                candidateValues
+                                        )
+                                );
+
+                                if (directMatch || variantMatch) {
+                                        categoryDocument = categoryEntry;
+                                        matchedCategoryCandidateValues = candidateValues;
+                                        break;
+                                }
+                        }
+
+                        if (categoryDocument) {
+                                const orConditions = [];
+                                const combinedCategoryValues = new Set([
+                                        ...matchedCategoryCandidateValues,
+                                        ...categoryVariantsToCheck,
+                                ]);
+
+                                const categoryRegexes = buildRegexArray(
+                                        Array.from(combinedCategoryValues)
+                                );
+
+                                if (categoryRegexes.length > 0) {
+                                        orConditions.push({ category: { $in: categoryRegexes } });
+                                }
+
+                                const subCategoryCandidates = new Set();
+
+                                categoryDocument.subCategories?.forEach((subCategory) => {
+                                        appendValueAndVariants(
+                                                subCategoryCandidates,
+                                                subCategory?.name
+                                        );
+
+                                        if (subCategory?.slug) {
+                                                appendValueAndVariants(
+                                                        subCategoryCandidates,
+                                                        subCategory.slug
+                                                );
+                                        }
+
+                                        if (subCategory?._id) {
+                                                appendValueAndVariants(
+                                                        subCategoryCandidates,
+                                                        subCategory._id.toString()
+                                                );
+                                        }
+                                });
+
+                                const subCategoryRegexes = buildRegexArray(
+                                        Array.from(subCategoryCandidates)
+                                );
+
+                                if (subCategoryRegexes.length > 0) {
+                                        orConditions.push({
+                                                subCategory: { $in: subCategoryRegexes },
+                                        });
+                                }
+
+                                if (orConditions.length > 0) {
+                                        ensureAndConditions(query).push({ $or: orConditions });
+                                } else if (categoryDocument.name) {
+                                        query.category = categoryDocument.name;
+                                } else {
+                                        query.category = category;
+                                }
+                        } else {
+                                const fallbackCategoryValues = new Set();
+
+                                categoryVariantsToCheck.forEach((value) =>
+                                        appendValueAndVariants(fallbackCategoryValues, value)
+                                );
+
+                                const fallbackCategoryRegexes = buildRegexArray(
+                                        Array.from(fallbackCategoryValues)
+                                );
+
+                                if (fallbackCategoryRegexes.length > 0) {
+                                        ensureAndConditions(query).push({
+                                                category: { $in: fallbackCategoryRegexes },
+                                        });
+                                } else {
+                                        query.category = category;
+                                }
+                        }
+                }
 
 		// Search filter
 		if (search) {
@@ -356,10 +586,20 @@ export async function GET(request) {
 				salePrice: product.salePrice,
 				discount: product.discount,
 				discountPercentage,
-				image:
-					product.images?.[0] ||
-					"https://res.cloudinary.com/drjt9guif/image/upload/v1755168534/safetyonline_fks0th.png",
-				images: product.images || [],
+                                image:
+                                        product.images?.find(
+                                                (img) =>
+                                                        typeof img === "string" && img.trim().length > 0
+                                        ) ||
+                                        "https://res.cloudinary.com/drjt9guif/image/upload/v1755168534/safetyonline_fks0th.png",
+                                images:
+                                        Array.isArray(product.images)
+                                                ? product.images.filter(
+                                                          (img) =>
+                                                                  typeof img === "string" &&
+                                                                  img.trim().length > 0
+                                                  )
+                                                : [],
 				category: product.category,
 				subCategory: product.subCategory,
 				inStock: product.inStock,


### PR DESCRIPTION
## Summary
- normalize subcategory filters by aggregating all matching id, slug, and name variants before querying products
- reuse cached published categories to resolve category ids/slugs to names and keep category filtering consistent even when subcategory is supplied
