### PR TITLE
Fix missing slug expression helper in products API

### DIFF
--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -95,6 +95,35 @@ export async function GET(request) {
                 };
 
 
+                const buildSlugExpression = (fieldPath) => ({
+                        $let: {
+                                vars: {
+                                        normalized: {
+                                                $toLower: {
+                                                        $trim: {
+                                                                input: {
+                                                                        $ifNull: [fieldPath, ""],
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                                in: {
+                                        $trim: {
+                                                input: {
+                                                        $regexReplace: {
+                                                                input: "$${normalized}",
+                                                                regex: "[^a-z0-9]+",
+                                                                replacement: "-",
+                                                        },
+                                                },
+                                                chars: "-",
+                                        },
+                                },
+                        },
+                });
+
+
                 const appendValueAndVariants = (set, rawValue) => {
                         if (rawValue === undefined || rawValue === null) {
                                 return;


### PR DESCRIPTION
## Summary
- add an inline MongoDB expression helper that slugifies subcategory fields before comparison to avoid runtime errors in the products API
