### PR TITLE
Handle expired tokens by logging out users

### DIFF
--- a/store/authStore.js
+++ b/store/authStore.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
@@ -7,7 +9,24 @@ export const useAuthStore = create(
 			(set) => ({
 				user: null,
 				setUser: (user) => set({ user }),
-				clearUser: () => set({ user: null }),
+                                clearUser: () => set({ user: null }),
+                                logout: async (redirectPath = "/login") => {
+                                        set({ user: null });
+
+                                        if (typeof window === "undefined") {
+                                                return;
+                                        }
+
+                                        try {
+                                                await fetch("/api/auth/logout", { method: "POST" });
+                                        } catch (error) {
+                                                console.error("Failed to call logout endpoint:", error);
+                                        } finally {
+                                                if (window.location.pathname !== redirectPath) {
+                                                        window.location.href = redirectPath;
+                                                }
+                                        }
+                                },
 			}),
 			{
 				name: "logged-in-user",


### PR DESCRIPTION
## Summary
- add a logout helper to the auth store that clears the client session and redirects to the login screen when invoked
- update cart and wishlist stores to treat 401 responses as expired sessions, reuse the logout helper, and show a clear session-expired toast
- ensure cart promo removal awaits the server response so unauthorized sessions are caught before showing success
