### PR TITLE
Handle missing order metadata in seller orders page

### DIFF
--- a/app/seller/orders/page.jsx
+++ b/app/seller/orders/page.jsx
@@ -92,7 +92,10 @@ function SellerOrdersPage() {
 	};
 
         const handleDownloadReceipt = async (order) => {
-                const result = await downloadShipmentReceipt(order._id, order.orderNumber);
+                const orderNumber =
+                        order?.orderId?.orderNumber || order?.orderNumber || order?._id || "order";
+
+                const result = await downloadShipmentReceipt(order._id, orderNumber);
                 if (result.success) {
                         toast.success("Shipment receipt downloaded successfully");
                 } else {
@@ -358,15 +361,15 @@ function SellerOrdersPage() {
 											transition={{ duration: 0.2 }}
 										>
 											<TableCell className="font-medium">
-												{order.orderId.orderNumber}
+												{order.orderId?.orderNumber || order.orderNumber || "N/A"}
 											</TableCell>
 											<TableCell>
-												{new Date(order.orderId.orderDate).toLocaleDateString()}
+												{order.orderId?.orderDate ? new Date(order.orderId.orderDate).toLocaleDateString() : "N/A"}
 												<br />
 												<span className="text-xs text-gray-500">
-													{new Date(
-														order.orderId.orderDate
-													).toLocaleTimeString()}
+													{order.orderId?.orderDate
+															? new Date(order.orderId.orderDate).toLocaleTimeString()
+															: ""}
 												</span>
 											</TableCell>
 											<TableCell>
@@ -403,7 +406,7 @@ function SellerOrdersPage() {
 											</TableCell>
 											<TableCell>
 												<Badge className="bg-blue-100 text-blue-800">
-													{getPaymentMethodDisplay(order.orderId.paymentMethod)}
+													{getPaymentMethodDisplay(order.orderId?.paymentMethod || order.paymentMethod)}
 												</Badge>
 											</TableCell>
 											<TableCell className="font-medium text-green-600">


### PR DESCRIPTION
## Summary
- add fallbacks when downloading seller shipment receipts so missing order numbers do not crash the page
- guard seller order table cells against absent order details to avoid runtime errors
