### PR TITLE
Make seller account settings dynamic with centralized company store

### DIFF
--- a/app/seller/account-settings/page.jsx
+++ b/app/seller/account-settings/page.jsx
@@ -1,53 +1,115 @@
 "use client";
 
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import ShopForm from "@/components/SellerPanel/Settings/form";
 import CompanyAddresses from "@/components/SellerPanel/Settings/address";
+import LoadingSpinner from "@/components/SellerPanel/Layout/LoadingSpinner.jsx";
+import { useSellerCompanyStore } from "@/store/sellerCompanyStore.js";
+import { useIsSellerAuthenticated } from "@/store/sellerAuthStore";
 
 export default function AccountSettings() {
-	return (
-		<div className="min-h-screen bg-gray-50 p-6 md:p-10">
-			<div className="w-full space-y-8">
-				<motion.div
-					initial={{ opacity: 0, y: 10 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.25 }}
-				>
-					<Card className="border-none shadow-md p-6">
-						<CardHeader className="p-0 pb-2">
-							<CardTitle className="text-2xl font-bold text-gray-900">
-								Seller Account Settings
-							</CardTitle>
-							<CardDescription className="text-gray-600">
-								Manage your company profile and addresses.
-							</CardDescription>
-						</CardHeader>
-					</Card>
-				</motion.div>
+        const router = useRouter();
+        const isAuthenticated = useIsSellerAuthenticated();
+        const { loading, initialized, error, fetchCompany } = useSellerCompanyStore((state) => ({
+                loading: state.loading,
+                initialized: state.initialized,
+                error: state.error,
+                fetchCompany: state.fetchCompany,
+        }));
 
-				<motion.div
-					initial={{ opacity: 0, y: 10 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.25, delay: 0.05 }}
-				>
-					<ShopForm />
-				</motion.div>
+        useEffect(() => {
+                if (!isAuthenticated) {
+                        const timer = setTimeout(() => {
+                                router.push("/seller/login");
+                        }, 100);
+                        return () => clearTimeout(timer);
+                }
+        }, [isAuthenticated, router]);
 
-				<motion.div
-					initial={{ opacity: 0, y: 10 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.25, delay: 0.1 }}
-				>
-					<CompanyAddresses />
-				</motion.div>
-			</div>
-		</div>
-	);
+        useEffect(() => {
+                if (isAuthenticated && !initialized) {
+                        fetchCompany().catch(() => undefined);
+                }
+        }, [isAuthenticated, initialized, fetchCompany]);
+
+        if (!isAuthenticated) {
+                return (
+                        <div className="flex items-center justify-center bg-white py-10 text-gray-600">
+                                Redirecting to login...
+                        </div>
+                );
+        }
+
+        const isInitialLoading = loading && !initialized;
+
+        return (
+                <div className="min-h-screen bg-gray-50 p-6 md:p-10">
+                        <div className="w-full space-y-8">
+                                <motion.div
+                                        initial={{ opacity: 0, y: 10 }}
+                                        animate={{ opacity: 1, y: 0 }}
+                                        transition={{ duration: 0.25 }}
+                                >
+                                        <Card className="p-6 border-none shadow-md">
+                                                <CardHeader className="p-0 pb-2">
+                                                        <CardTitle className="text-2xl font-bold text-gray-900">
+                                                                Seller Account Settings
+                                                        </CardTitle>
+                                                        <CardDescription className="text-gray-600">
+                                                                Manage your company profile and addresses.
+                                                        </CardDescription>
+                                                </CardHeader>
+                                                {error && (
+                                                        <CardContent className="mt-4 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                                                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                                                        <span>{error}</span>
+                                                                        <Button
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                onClick={() => fetchCompany(true)}
+                                                                        >
+                                                                                Retry
+                                                                        </Button>
+                                                                </div>
+                                                        </CardContent>
+                                                )}
+                                        </Card>
+                                </motion.div>
+
+                                {isInitialLoading ? (
+                                        <div className="rounded-lg border border-dashed border-gray-200 bg-white py-10">
+                                                <LoadingSpinner />
+                                        </div>
+                                ) : (
+                                        <>
+                                                <motion.div
+                                                        initial={{ opacity: 0, y: 10 }}
+                                                        animate={{ opacity: 1, y: 0 }}
+                                                        transition={{ duration: 0.25, delay: 0.05 }}
+                                                >
+                                                        <ShopForm />
+                                                </motion.div>
+
+                                                <motion.div
+                                                        initial={{ opacity: 0, y: 10 }}
+                                                        animate={{ opacity: 1, y: 0 }}
+                                                        transition={{ duration: 0.25, delay: 0.1 }}
+                                                >
+                                                        <CompanyAddresses />
+                                                </motion.div>
+                                        </>
+                                )}
+                        </div>
+                </div>
+        );
 }

--- a/components/SellerPanel/Settings/address.jsx
+++ b/components/SellerPanel/Settings/address.jsx
@@ -2,229 +2,245 @@
 
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Pencil, Trash2, Plus, Save, X } from "lucide-react";
+import { Pencil, Trash2, Plus, Save, X, Loader2 } from "lucide-react";
 import {
-	Card,
-	CardHeader,
-	CardTitle,
-	CardDescription,
-	CardContent,
+        Card,
+        CardHeader,
+        CardTitle,
+        CardDescription,
+        CardContent,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { addressSchema } from "@/zodSchema/companyScema.js";
+import { useSellerCompanyStore } from "@/store/sellerCompanyStore.js";
+
+const EMPTY_DRAFT = {
+        tagName: "",
+        building: "",
+        street: "",
+        city: "",
+        state: "",
+        pincode: "",
+        country: "",
+};
 
 export default function CompanyAddresses() {
-	const [addresses, setAddresses] = useState([]);
-	const [loading, setLoading] = useState(true);
-	const [editingIndex, setEditingIndex] = useState(-1);
-	const [draft, setDraft] = useState({
-		tagName: "",
-		building: "",
-		street: "",
-		city: "",
-		state: "",
-		pincode: "",
-		country: "",
-	});
+        const {
+                company,
+                loading,
+                initialized,
+                addressesSaving,
+                fetchCompany,
+                updateAddresses,
+        } = useSellerCompanyStore((state) => ({
+                company: state.company,
+                loading: state.loading,
+                initialized: state.initialized,
+                addressesSaving: state.addressesSaving,
+                fetchCompany: state.fetchCompany,
+                updateAddresses: state.updateAddresses,
+        }));
 
-	const resetDraft = () =>
-		setDraft({
-			tagName: "",
-			building: "",
-			street: "",
-			city: "",
-			state: "",
-			pincode: "",
-			country: "",
-		});
+        const [addresses, setAddresses] = useState([]);
+        const [editingIndex, setEditingIndex] = useState(-1);
+        const [draft, setDraft] = useState(EMPTY_DRAFT);
 
-	useEffect(() => {
-		let mounted = true;
-		(async () => {
-			try {
-				const res = await fetch("/api/seller/company/getCompany", {
-					credentials: "include",
-				});
-				if (res.ok) {
-					const data = await res.json();
-					if (mounted) setAddresses(data?.company?.companyAddress || []);
-				}
-			} catch (e) {
-				// noop
-			} finally {
-				if (mounted) setLoading(false);
-			}
-		})();
-		return () => {
-			mounted = false;
-		};
-	}, []);
+        useEffect(() => {
+                if (!initialized) {
+                        fetchCompany().catch(() => undefined);
+                }
+        }, [initialized, fetchCompany]);
 
-	const startAdd = () => {
-		resetDraft();
-		setEditingIndex(addresses.length);
-	};
+        useEffect(() => {
+                setAddresses(company?.companyAddress || []);
+        }, [company]);
 
-	const startEdit = (i) => {
-		setDraft(addresses[i]);
-		setEditingIndex(i);
-	};
+        const resetDraft = () => {
+                setDraft(EMPTY_DRAFT);
+        };
 
-	const cancelEdit = () => {
-		resetDraft();
-		setEditingIndex(-1);
-	};
+        const startAdd = () => {
+                if (!company?._id) {
+                        toast.error("Create your company profile before adding addresses.");
+                        return;
+                }
+                resetDraft();
+                setEditingIndex(addresses.length);
+        };
 
-	const removeAddress = async (i) => {
-		const next = addresses.filter((_, idx) => idx !== i);
-		try {
-			const res = await fetch("/api/seller/company/updateCompany", {
-				method: "PUT",
-				headers: { "Content-Type": "application/json" },
-				credentials: "include",
-				body: JSON.stringify({ companyAddress: next }),
-			});
-			if (!res.ok) throw new Error("Failed to remove address");
-			setAddresses(next);
-			toast.success("Address removed");
-		} catch (err) {
-			toast.error(err.message);
-		}
-	};
+        const startEdit = (index) => {
+                if (!company?._id) {
+                        toast.error("Create your company profile before editing addresses.");
+                        return;
+                }
+                setDraft({ ...addresses[index] });
+                setEditingIndex(index);
+        };
 
-	const saveDraft = async () => {
-		const parsed = addressSchema.safeParse(draft);
-		if (!parsed.success) {
-			toast.error(parsed.error.errors[0].message);
-			return;
-		}
-		const next = [...addresses];
-		next[editingIndex] = parsed.data;
-		try {
-			const res = await fetch("/api/seller/company/updateCompany", {
-				method: "PUT",
-				headers: { "Content-Type": "application/json" },
-				credentials: "include",
-				body: JSON.stringify({ companyAddress: next }),
-			});
-			if (!res.ok) throw new Error("Failed to save address");
-			setAddresses(next);
-			toast.success(
-				editingIndex >= addresses.length ? "Address added" : "Address updated"
-			);
-			cancelEdit();
-		} catch (err) {
-			toast.error(err.message);
-		}
-	};
+        const cancelEdit = () => {
+                resetDraft();
+                setEditingIndex(-1);
+        };
 
-	if (loading) {
-		return (
-			<Card>
-				<CardHeader>
-					<CardTitle>Company Addresses</CardTitle>
-					<CardDescription>Loading addresses…</CardDescription>
-				</CardHeader>
-			</Card>
-		);
-	}
+        const removeAddress = async (index) => {
+                if (!company?._id) {
+                        toast.error("Create your company profile before managing addresses.");
+                        return;
+                }
+                const next = addresses.filter((_, idx) => idx !== index);
+                const result = await updateAddresses(next);
+                if (result.success) {
+                        setAddresses(next);
+                        toast.success("Address removed");
+                } else {
+                        toast.error(result.message || "Failed to remove address");
+                }
+        };
 
-	return (
-		<Card className="border border-gray-200">
-			<CardHeader className="flex-row items-center justify-between">
-				<div>
-					<CardTitle>Company Addresses</CardTitle>
-					<CardDescription>
-						Add or update your company addresses
-					</CardDescription>
-				</div>
-				<Button onClick={startAdd} variant="secondary" size="sm">
-					<Plus className="h-4 w-4 mr-1" /> Add address
-				</Button>
-			</CardHeader>
-			<CardContent className="space-y-5">
-				{editingIndex !== -1 && (
-					<div className="rounded-lg border p-4 grid gap-3">
-						{[
-							{ label: "Tag", name: "tagName", placeholder: "Head Office" },
-							{
-								label: "Building",
-								name: "building",
-								placeholder: "Building / Suite",
-							},
-							{ label: "Street", name: "street", placeholder: "Street" },
-							{ label: "City", name: "city", placeholder: "City" },
-							{ label: "State", name: "state", placeholder: "State" },
-							{ label: "Pincode", name: "pincode", placeholder: "Pincode" },
-							{ label: "Country", name: "country", placeholder: "Country" },
-						].map((f) => (
-							<div key={f.name} className="grid gap-1">
-								<Label htmlFor={f.name}>{f.label}</Label>
-								<Input
-									id={f.name}
-									value={draft[f.name] || ""}
-									onChange={(e) =>
-										setDraft((d) => ({ ...d, [f.name]: e.target.value }))
-									}
-									placeholder={f.placeholder}
-								/>
-							</div>
-						))}
-						<div className="flex justify-end gap-2">
-							<Button variant="outline" onClick={cancelEdit}>
-								<X className="mr-1 h-4 w-4" /> Cancel
-							</Button>
-							<Button onClick={saveDraft}>
-								<Save className="mr-1 h-4 w-4" /> Save
-							</Button>
-						</div>
-					</div>
-				)}
+        const saveDraft = async () => {
+                if (!company?._id) {
+                        toast.error("Create your company profile before adding addresses.");
+                        return;
+                }
+                const parsed = addressSchema.safeParse(draft);
+                if (!parsed.success) {
+                        toast.error(parsed.error.errors[0].message);
+                        return;
+                }
+                const next = [...addresses];
+                next[editingIndex] = parsed.data;
+                const result = await updateAddresses(next);
+                if (result.success) {
+                        setAddresses(next);
+                        toast.success(
+                                editingIndex >= addresses.length ? "Address added" : "Address updated"
+                        );
+                        cancelEdit();
+                } else {
+                        toast.error(result.message || "Failed to save address");
+                }
+        };
 
-				{addresses.length === 0 ? (
-					<p className="text-sm text-gray-500">No addresses added yet.</p>
-				) : (
-					<div className="grid gap-3">
-						{addresses.map((addr, idx) => (
-							<div
-								key={idx}
-								className="rounded-lg border p-4 flex items-start justify-between"
-							>
-								<div className="text-sm">
-									<p className="font-medium text-gray-900">{addr.tagName}</p>
-									<p className="text-gray-700">
-										{addr.building}, {addr.street}
-									</p>
-									<p className="text-gray-700">
-										{addr.city}, {addr.state} {addr.pincode}
-									</p>
-									<p className="text-gray-700">{addr.country}</p>
-								</div>
-								<div className="flex gap-2">
-									<Button
-										variant="ghost"
-										size="icon"
-										onClick={() => startEdit(idx)}
-										aria-label="Edit"
-									>
-										<Pencil className="h-4 w-4" />
-									</Button>
-									<Button
-										variant="ghost"
-										size="icon"
-										onClick={() => removeAddress(idx)}
-										aria-label="Delete"
-									>
-										<Trash2 className="h-4 w-4" />
-									</Button>
-								</div>
-							</div>
-						))}
-					</div>
-				)}
-			</CardContent>
-		</Card>
-	);
+        const isInitializing = loading && !initialized;
+
+        if (isInitializing) {
+                return (
+                        <Card className="border border-gray-200">
+                                <CardHeader>
+                                        <CardTitle>Company Addresses</CardTitle>
+                                        <CardDescription>Loading addresses…</CardDescription>
+                                </CardHeader>
+                        </Card>
+                );
+        }
+
+        return (
+                <Card className="border border-gray-200">
+                        <CardHeader className="flex-row items-center justify-between">
+                                <div>
+                                        <CardTitle>Company Addresses</CardTitle>
+                                        <CardDescription>
+                                                Add or update your company addresses
+                                        </CardDescription>
+                                </div>
+                                <Button onClick={startAdd} variant="secondary" size="sm" disabled={addressesSaving}>
+                                        <Plus className="mr-1 h-4 w-4" /> Add address
+                                </Button>
+                        </CardHeader>
+                        <CardContent className="space-y-5">
+                                {editingIndex !== -1 && (
+                                        <div className="grid gap-3 rounded-lg border p-4">
+                                                {[
+                                                        { label: "Tag", name: "tagName", placeholder: "Head Office" },
+                                                        {
+                                                                label: "Building",
+                                                                name: "building",
+                                                                placeholder: "Building / Suite",
+                                                        },
+                                                        { label: "Street", name: "street", placeholder: "Street" },
+                                                        { label: "City", name: "city", placeholder: "City" },
+                                                        { label: "State", name: "state", placeholder: "State" },
+                                                        { label: "Pincode", name: "pincode", placeholder: "Pincode" },
+                                                        { label: "Country", name: "country", placeholder: "Country" },
+                                                ].map((field) => (
+                                                        <div key={field.name} className="grid gap-1">
+                                                                <Label htmlFor={field.name}>{field.label}</Label>
+                                                                <Input
+                                                                        id={field.name}
+                                                                        value={draft[field.name] || ""}
+                                                                        onChange={(e) =>
+                                                                                setDraft((d) => ({ ...d, [field.name]: e.target.value }))
+                                                                        }
+                                                                        placeholder={field.placeholder}
+                                                                        disabled={addressesSaving}
+                                                                />
+                                                        </div>
+                                                ))}
+                                                <div className="flex justify-end gap-2">
+                                                        <Button variant="outline" onClick={cancelEdit} disabled={addressesSaving}>
+                                                                <X className="mr-1 h-4 w-4" /> Cancel
+                                                        </Button>
+                                                        <Button onClick={saveDraft} disabled={addressesSaving}>
+                                                                {addressesSaving ? (
+                                                                        <>
+                                                                                <Loader2 className="mr-1 h-4 w-4 animate-spin" /> Save
+                                                                        </>
+                                                                ) : (
+                                                                        <>
+                                                                                <Save className="mr-1 h-4 w-4" /> Save
+                                                                        </>
+                                                                )}
+                                                        </Button>
+                                                </div>
+                                        </div>
+                                )}
+
+                                {addresses.length === 0 ? (
+                                        <p className="text-sm text-gray-500">No addresses added yet.</p>
+                                ) : (
+                                        <div className="grid gap-3">
+                                                {addresses.map((addr, idx) => (
+                                                        <div
+                                                                key={`${addr.tagName}-${idx}`}
+                                                                className="flex items-start justify-between rounded-lg border p-4"
+                                                        >
+                                                                <div className="text-sm">
+                                                                        <p className="font-medium text-gray-900">{addr.tagName}</p>
+                                                                        <p className="text-gray-700">
+                                                                                {addr.building}, {addr.street}
+                                                                        </p>
+                                                                        <p className="text-gray-700">
+                                                                                {addr.city}, {addr.state} {addr.pincode}
+                                                                        </p>
+                                                                        <p className="text-gray-700">{addr.country}</p>
+                                                                </div>
+                                                                <div className="flex gap-2">
+                                                                        <Button
+                                                                                variant="ghost"
+                                                                                size="icon"
+                                                                                onClick={() => startEdit(idx)}
+                                                                                aria-label="Edit"
+                                                                                disabled={addressesSaving}
+                                                                        >
+                                                                                <Pencil className="h-4 w-4" />
+                                                                        </Button>
+                                                                        <Button
+                                                                                variant="ghost"
+                                                                                size="icon"
+                                                                                onClick={() => removeAddress(idx)}
+                                                                                aria-label="Delete"
+                                                                                disabled={addressesSaving}
+                                                                        >
+                                                                                <Trash2 className="h-4 w-4" />
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                ))}
+                                        </div>
+                                )}
+                        </CardContent>
+                </Card>
+        );
 }

--- a/components/SellerPanel/Settings/form.jsx
+++ b/components/SellerPanel/Settings/form.jsx
@@ -4,255 +4,257 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import Image from "next/image";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Loader2, UploadCloud, ImageIcon } from "lucide-react";
 import { companyBaseSchema } from "@/zodSchema/companyScema.js";
+import { useSellerCompanyStore } from "@/store/sellerCompanyStore.js";
+
+const EMPTY_FORM = {
+        companyName: "",
+        companyEmail: "",
+        phone: "",
+        gstinNumber: "",
+        companyLogo: "",
+};
 
 export default function ShopForm() {
-	const [form, setForm] = useState({
-		companyName: "",
-		companyEmail: "",
-		phone: "",
-		gstinNumber: "",
-		companyLogo: "",
-	});
-	const [loading, setLoading] = useState(false);
-	const [logoUploading, setLogoUploading] = useState(false);
-	const [hasCompany, setHasCompany] = useState(false);
+        const {
+                company,
+                loading,
+                initialized,
+                saving,
+                uploadingLogo,
+                fetchCompany,
+                saveCompany,
+                uploadLogo,
+                setCompany,
+        } = useSellerCompanyStore((state) => ({
+                company: state.company,
+                loading: state.loading,
+                initialized: state.initialized,
+                saving: state.saving,
+                uploadingLogo: state.uploadingLogo,
+                fetchCompany: state.fetchCompany,
+                saveCompany: state.saveCompany,
+                uploadLogo: state.uploadLogo,
+                setCompany: state.setCompany,
+        }));
 
-	useEffect(() => {
-		let isMounted = true;
-		(async () => {
-			try {
-				const res = await fetch("/api/seller/company/getCompany", {
-					credentials: "include",
-				});
-				if (res.ok) {
-					const data = await res.json();
-					const c = data.company;
-					if (isMounted && c) {
-						setForm({
-							companyName: c.companyName || "",
-							companyEmail: c.companyEmail || "",
-							phone: c.phone || "",
-							gstinNumber: c.gstinNumber || "",
-							companyLogo: c.companyLogo || "",
-						});
-						setHasCompany(true);
-					}
-				} else {
-					setHasCompany(false);
-				}
-			} catch {
-				setHasCompany(false);
-			}
-		})();
-		return () => {
-			isMounted = false;
-		};
-	}, []);
+        const [form, setForm] = useState(EMPTY_FORM);
 
-	const onChange = (e) => {
-		const { name, value } = e.target;
-		setForm((s) => ({ ...s, [name]: value }));
-	};
+        useEffect(() => {
+                if (!initialized) {
+                        fetchCompany().catch(() => undefined);
+                }
+        }, [initialized, fetchCompany]);
 
-	const handleLogoChange = async (e) => {
-		const file = e.target.files?.[0];
-		if (!file) return;
-		if (!file.type.startsWith("image/")) {
-			toast.error("Please select an image file");
-			return;
-		}
-		if (file.size > 3 * 1024 * 1024) {
-			toast.error("Max file size is 3MB");
-			return;
-		}
-		setLogoUploading(true);
-		try {
-			const fd = new FormData();
-			fd.append("file", file);
-			const res = await fetch("/api/seller/company/upload-logo", {
-				method: "POST",
-				body: fd,
-				credentials: "include",
-			});
-			const data = await res.json();
-			if (!res.ok) {
-				throw new Error(data?.error || "Upload failed");
-			}
-			setForm((s) => ({ ...s, companyLogo: data.url }));
-			toast.success("Logo uploaded");
-		} catch (err) {
-			toast.error(err.message || "Failed to upload logo");
-		} finally {
-			setLogoUploading(false);
-		}
-	};
+        useEffect(() => {
+                if (company) {
+                        setForm({
+                                companyName: company.companyName || "",
+                                companyEmail: company.companyEmail || "",
+                                phone: company.phone || "",
+                                gstinNumber: company.gstinNumber || "",
+                                companyLogo: company.companyLogo || "",
+                        });
+                } else {
+                        setForm(EMPTY_FORM);
+                }
+        }, [company]);
 
-	const handleSubmit = async (e) => {
-		e.preventDefault();
-		// Client-side Zod validation
-		const parsed = companyBaseSchema.safeParse(form);
-		if (!parsed.success) {
-			const first = parsed.error.errors[0];
-			toast.error(first.message);
-			return;
-		}
-		setLoading(true);
-		try {
-			const endpoint = hasCompany
-				? "/api/seller/company/updateCompany"
-				: "/api/seller/company/createCompany";
-			const method = hasCompany ? "PUT" : "POST";
-			const res = await fetch(endpoint, {
-				method,
-				headers: { "Content-Type": "application/json" },
-				credentials: "include",
-				body: JSON.stringify(form),
-			});
-			const data = await res.json();
-			if (!res.ok) throw new Error(data?.error || "Failed to save company");
-			setHasCompany(true);
-			toast.success(hasCompany ? "Company updated" : "Company created");
-		} catch (err) {
-			toast.error(err.message || "Failed to save");
-		} finally {
-			setLoading(false);
-		}
-	};
+        const onChange = (e) => {
+                const { name, value } = e.target;
+                setForm((s) => ({ ...s, [name]: value }));
+        };
 
-	return (
-		<Card className="border border-gray-200">
-			<CardHeader>
-				<CardTitle>Company Profile</CardTitle>
-				<CardDescription>
-					Basic company details. Manage addresses below.
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<form onSubmit={handleSubmit} className="grid gap-6">
-					<div className="grid grid-cols-1 md:grid-cols-[1fr,220px] gap-6">
-						<div className="grid gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="companyName">Company Name</Label>
-								<Input
-									id="companyName"
-									name="companyName"
-									value={form.companyName}
-									onChange={onChange}
-									placeholder="Acme Industries Pvt. Ltd."
-									required
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="companyEmail">Company Email</Label>
-								<Input
-									id="companyEmail"
-									name="companyEmail"
-									type="email"
-									value={form.companyEmail}
-									onChange={onChange}
-									placeholder="support@company.com"
-									required
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="phone">Company Phone</Label>
-								<Input
-									id="phone"
-									name="phone"
-									inputMode="numeric"
-									pattern="[0-9]*"
-									value={form.phone}
-									onChange={onChange}
-									placeholder="10-15 digit number"
-									required
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="gstinNumber">GSTIN (optional)</Label>
-								<Input
-									id="gstinNumber"
-									name="gstinNumber"
-									value={form.gstinNumber}
-									onChange={onChange}
-									placeholder="22AAAAA0000A1Z5"
-								/>
-							</div>
-						</div>
+        const handleLogoChange = async (e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                if (!file.type.startsWith("image/")) {
+                        toast.error("Please select an image file");
+                        return;
+                }
+                if (file.size > 3 * 1024 * 1024) {
+                        toast.error("Max file size is 3MB");
+                        return;
+                }
 
-						<div className="space-y-3">
-							<Label>Company Logo</Label>
-							<div className="rounded-lg border border-dashed p-3 flex flex-col items-center justify-center text-center">
-								{form.companyLogo ? (
-									<div className="w-full">
-										<Image
-											src={form.companyLogo || "/placeholder.svg"}
-											alt="Company Logo"
-											width={320}
-											height={160}
-											className="mx-auto h-28 w-auto object-contain"
-											onError={() =>
-												setForm((s) => ({ ...s, companyLogo: "" }))
-											}
-										/>
-									</div>
-								) : (
-									<div className="flex flex-col items-center gap-2 text-gray-500">
-										<ImageIcon className="h-10 w-10" />
-										<p className="text-sm">No logo uploaded</p>
-									</div>
-								)}
-								<div className="mt-3 flex items-center gap-2">
-									<label className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm cursor-pointer hover:bg-gray-50">
-										<UploadCloud className="h-4 w-4" />
-										<span>{logoUploading ? "Uploading..." : "Upload"}</span>
-										<input
-											type="file"
-											accept="image/*"
-											className="hidden"
-											onChange={handleLogoChange}
-											disabled={logoUploading}
-										/>
-									</label>
-									{form.companyLogo && (
-										<Button
-											type="button"
-											variant="secondary"
-											onClick={() =>
-												setForm((s) => ({ ...s, companyLogo: "" }))
-											}
-										>
-											Remove
-										</Button>
-									)}
-								</div>
-							</div>
-						</div>
-					</div>
+                const result = await uploadLogo(file);
+                if (result?.success && result.url) {
+                        setForm((s) => ({ ...s, companyLogo: result.url }));
+                        toast.success("Logo uploaded");
+                } else if (result?.message) {
+                        toast.error(result.message);
+                } else {
+                        toast.error("Failed to upload logo");
+                }
+        };
 
-					<div className="flex justify-end">
-						<Button type="submit" disabled={loading}>
-							{loading ? (
-								<>
-									<Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
-								</>
-							) : (
-								"Save"
-							)}
-						</Button>
-					</div>
-				</form>
-			</CardContent>
-		</Card>
-	);
+        const handleSubmit = async (e) => {
+                e.preventDefault();
+                const parsed = companyBaseSchema.safeParse(form);
+                if (!parsed.success) {
+                        const first = parsed.error.errors[0];
+                        toast.error(first.message);
+                        return;
+                }
+
+                const existed = Boolean(company?._id);
+                const result = await saveCompany(parsed.data);
+                if (result.success) {
+                        toast.success(
+                                result.message || (existed ? "Company updated" : "Company created")
+                        );
+                } else {
+                        toast.error(result.message || "Failed to save company");
+                }
+        };
+
+        const handleLogoError = () => {
+                setForm((s) => ({ ...s, companyLogo: "" }));
+                setCompany((current) =>
+                        current ? { ...current, companyLogo: "" } : current
+                );
+        };
+
+        const isInitializing = loading && !initialized;
+        const disableFields = isInitializing || saving;
+
+        return (
+                <Card className="border border-gray-200">
+                        <CardHeader>
+                                <CardTitle>Company Profile</CardTitle>
+                                <CardDescription>
+                                        Basic company details. Manage addresses below.
+                                </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                                <form onSubmit={handleSubmit} className="grid gap-6">
+                                        <div className="grid grid-cols-1 gap-6 md:grid-cols-[1fr,220px]">
+                                                <div className="grid gap-4">
+                                                        <div className="grid gap-2">
+                                                                <Label htmlFor="companyName">Company Name</Label>
+                                                                <Input
+                                                                        id="companyName"
+                                                                        name="companyName"
+                                                                        value={form.companyName}
+                                                                        onChange={onChange}
+                                                                        placeholder="Acme Industries Pvt. Ltd."
+                                                                        required
+                                                                        disabled={disableFields}
+                                                                />
+                                                        </div>
+                                                        <div className="grid gap-2">
+                                                                <Label htmlFor="companyEmail">Company Email</Label>
+                                                                <Input
+                                                                        id="companyEmail"
+                                                                        name="companyEmail"
+                                                                        type="email"
+                                                                        value={form.companyEmail}
+                                                                        onChange={onChange}
+                                                                        placeholder="support@company.com"
+                                                                        required
+                                                                        disabled={disableFields}
+                                                                />
+                                                        </div>
+                                                        <div className="grid gap-2">
+                                                                <Label htmlFor="phone">Company Phone</Label>
+                                                                <Input
+                                                                        id="phone"
+                                                                        name="phone"
+                                                                        inputMode="numeric"
+                                                                        pattern="[0-9]*"
+                                                                        value={form.phone}
+                                                                        onChange={onChange}
+                                                                        placeholder="10-15 digit number"
+                                                                        required
+                                                                        disabled={disableFields}
+                                                                />
+                                                        </div>
+                                                        <div className="grid gap-2">
+                                                                <Label htmlFor="gstinNumber">GSTIN (optional)</Label>
+                                                                <Input
+                                                                        id="gstinNumber"
+                                                                        name="gstinNumber"
+                                                                        value={form.gstinNumber}
+                                                                        onChange={onChange}
+                                                                        placeholder="22AAAAA0000A1Z5"
+                                                                        disabled={disableFields}
+                                                                />
+                                                        </div>
+                                                </div>
+
+                                                <div className="space-y-3">
+                                                        <Label>Company Logo</Label>
+                                                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-3 text-center">
+                                                                {form.companyLogo ? (
+                                                                        <div className="w-full">
+                                                                                <Image
+                                                                                        src={form.companyLogo || "/placeholder.svg"}
+                                                                                        alt="Company Logo"
+                                                                                        width={320}
+                                                                                        height={160}
+                                                                                        className="mx-auto h-28 w-auto object-contain"
+                                                                                        onError={handleLogoError}
+                                                                                />
+                                                                        </div>
+                                                                ) : (
+                                                                        <div className="flex flex-col items-center gap-2 text-gray-500">
+                                                                                <ImageIcon className="h-10 w-10" />
+                                                                                <p className="text-sm">No logo uploaded</p>
+                                                                        </div>
+                                                                )}
+                                                                <div className="mt-3 flex items-center gap-2">
+                                                                        <label
+                                                                                className="inline-flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-gray-50"
+                                                                                aria-disabled={uploadingLogo || disableFields}
+                                                                        >
+                                                                                <UploadCloud className="h-4 w-4" />
+                                                                                <span>{uploadingLogo ? "Uploading..." : "Upload"}</span>
+                                                                                <input
+                                                                                        type="file"
+                                                                                        accept="image/*"
+                                                                                        className="hidden"
+                                                                                        onChange={handleLogoChange}
+                                                                                        disabled={uploadingLogo || disableFields}
+                                                                                />
+                                                                        </label>
+                                                                        {form.companyLogo && (
+                                                                                <Button
+                                                                                        type="button"
+                                                                                        variant="secondary"
+                                                                                        onClick={handleLogoError}
+                                                                                        disabled={disableFields || uploadingLogo}
+                                                                                >
+                                                                                        Remove
+                                                                                </Button>
+                                                                        )}
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </div>
+
+                                        <div className="flex justify-end">
+                                                <Button type="submit" disabled={disableFields}>
+                                                        {saving ? (
+                                                                <>
+                                                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
+                                                                </>
+                                                        ) : (
+                                                                "Save"
+                                                        )}
+                                                </Button>
+                                        </div>
+                                </form>
+                        </CardContent>
+                </Card>
+        );
 }

--- a/store/sellerCompanyStore.js
+++ b/store/sellerCompanyStore.js
@@ -1,0 +1,209 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+const initialState = {
+        company: null,
+        loading: false,
+        saving: false,
+        addressesSaving: false,
+        uploadingLogo: false,
+        initialized: false,
+        error: null,
+};
+
+export const useSellerCompanyStore = create(
+        devtools(
+                (set, get) => ({
+                        ...initialState,
+                        fetchCompany: async (force = false) => {
+                                const state = get();
+                                if (state.loading) return state.company;
+                                if (state.initialized && !force) return state.company;
+
+                                set((s) => ({
+                                        ...s,
+                                        loading: true,
+                                        error: null,
+                                        ...(force ? { initialized: false } : {}),
+                                }));
+
+                                try {
+                                        const res = await fetch("/api/seller/company/getCompany", {
+                                                credentials: "include",
+                                        });
+                                        if (res.status === 404) {
+                                                set((s) => ({
+                                                        ...s,
+                                                        company: null,
+                                                        loading: false,
+                                                        initialized: true,
+                                                }));
+                                                return null;
+                                        }
+
+                                        if (res.status === 401) {
+                                                const message = "You must be logged in to manage your company details.";
+                                                set((s) => ({
+                                                        ...s,
+                                                        company: null,
+                                                        loading: false,
+                                                        initialized: true,
+                                                        error: message,
+                                                }));
+                                                return null;
+                                        }
+
+                                        if (!res.ok) {
+                                                const data = await res.json().catch(() => ({}));
+                                                throw new Error(data?.error || "Failed to fetch company details");
+                                        }
+
+                                        const data = await res.json();
+
+                                        set((s) => ({
+                                                ...s,
+                                                company: data.company || null,
+                                                loading: false,
+                                                initialized: true,
+                                        }));
+
+                                        return data.company;
+                                } catch (error) {
+                                        set((s) => ({
+                                                ...s,
+                                                loading: false,
+                                                initialized: true,
+                                                error: error.message || "Failed to load company details",
+                                        }));
+                                        return null;
+                                }
+                        },
+                        saveCompany: async (payload) => {
+                                const hasCompany = Boolean(get().company?._id);
+                                set((s) => ({ ...s, saving: true, error: null }));
+
+                                try {
+                                        const endpoint = hasCompany
+                                                ? "/api/seller/company/updateCompany"
+                                                : "/api/seller/company/createCompany";
+                                        const method = hasCompany ? "PUT" : "POST";
+
+                                        const res = await fetch(endpoint, {
+                                                method,
+                                                headers: { "Content-Type": "application/json" },
+                                                credentials: "include",
+                                                body: JSON.stringify(payload),
+                                        });
+                                        const data = await res.json().catch(() => ({}));
+
+                                        if (!res.ok) {
+                                                throw new Error(data?.error || "Failed to save company");
+                                        }
+
+                                        set((s) => ({
+                                                ...s,
+                                                company: data.company || s.company,
+                                                saving: false,
+                                                initialized: true,
+                                        }));
+
+                                        return {
+                                                success: true,
+                                                message:
+                                                        data?.message ||
+                                                        (hasCompany ? "Company updated successfully" : "Company created successfully"),
+                                                company: data.company,
+                                        };
+                                } catch (error) {
+                                        set((s) => ({
+                                                ...s,
+                                                saving: false,
+                                                error: error.message || "Failed to save company",
+                                        }));
+                                        return { success: false, message: error.message };
+                                }
+                        },
+                        uploadLogo: async (file) => {
+                                set((s) => ({ ...s, uploadingLogo: true, error: null }));
+                                try {
+                                        const fd = new FormData();
+                                        fd.append("file", file);
+                                        const res = await fetch("/api/seller/company/upload-logo", {
+                                                method: "POST",
+                                                body: fd,
+                                                credentials: "include",
+                                        });
+                                        const data = await res.json().catch(() => ({}));
+
+                                        if (!res.ok || !data?.url) {
+                                                throw new Error(data?.error || "Upload failed");
+                                        }
+
+                                        set((s) => ({
+                                                ...s,
+                                                uploadingLogo: false,
+                                                company: s.company
+                                                        ? { ...s.company, companyLogo: data.url }
+                                                        : s.company,
+                                        }));
+
+                                        return { success: true, url: data.url };
+                                } catch (error) {
+                                        set((s) => ({
+                                                ...s,
+                                                uploadingLogo: false,
+                                                error: error.message || "Failed to upload logo",
+                                        }));
+                                        return { success: false, message: error.message };
+                                }
+                        },
+                        updateAddresses: async (addresses) => {
+                                set((s) => ({ ...s, addressesSaving: true, error: null }));
+                                try {
+                                        const res = await fetch("/api/seller/company/updateCompany", {
+                                                method: "PUT",
+                                                headers: { "Content-Type": "application/json" },
+                                                credentials: "include",
+                                                body: JSON.stringify({ companyAddress: addresses }),
+                                        });
+                                        const data = await res.json().catch(() => ({}));
+                                        if (!res.ok) {
+                                                throw new Error(data?.error || "Failed to update addresses");
+                                        }
+
+                                        set((s) => ({
+                                                ...s,
+                                                addressesSaving: false,
+                                                company: data.company || s.company,
+                                        }));
+
+                                        return {
+                                                success: true,
+                                                message: data?.message || "Addresses updated successfully",
+                                                company: data.company,
+                                        };
+                                } catch (error) {
+                                        set((s) => ({
+                                                ...s,
+                                                addressesSaving: false,
+                                                error: error.message || "Failed to update addresses",
+                                        }));
+                                        return { success: false, message: error.message };
+                                }
+                        },
+                        setCompany: (updater) => {
+                                set((state) => ({
+                                        ...state,
+                                        company:
+                                                typeof updater === "function"
+                                                        ? updater(state.company)
+                                                        : updater,
+                                }));
+                        },
+                        clearError: () => set((s) => ({ ...s, error: null })),
+                        reset: () => set({ ...initialState }),
+                }),
+                { name: "seller-company-store" }
+        )
+);
+


### PR DESCRIPTION
## Summary
- add a dedicated seller company Zustand store to centralize fetching, saving, and uploading assets for company data
- update the seller account settings page to enforce authentication, surface loading/error states, and reuse the shared company store
- refactor the company profile and address components to consume the shared store, add validation messaging, and disable actions while mutations run
