### PR TITLE
Add admin analytics dashboard with comprehensive reporting

### DIFF
--- a/app/admin/analytics/page.jsx
+++ b/app/admin/analytics/page.jsx
@@ -1,0 +1,10 @@
+import dynamic from "next/dynamic";
+
+const AdminAnalytics = dynamic(
+        () => import("@/components/AdminPanel/Analytics/AdminAnalytics.jsx"),
+        { ssr: false }
+);
+
+export default function AdminAnalyticsPage() {
+        return <AdminAnalytics />;
+}

--- a/app/api/admin/analytics/route.js
+++ b/app/api/admin/analytics/route.js
@@ -1,0 +1,1098 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import mongoose from "mongoose";
+
+import { dbConnect } from "@/lib/dbConnect";
+import { verifyToken } from "@/lib/auth";
+import SubOrder from "@/model/SubOrder";
+import Product from "@/model/Product";
+import User from "@/model/User";
+
+const DEFAULT_INTERVAL = "day";
+const intervalOptions = new Set(["day", "week", "month"]);
+
+const toStartOfDay = (date) => {
+        const d = new Date(date);
+        d.setHours(0, 0, 0, 0);
+        return d;
+};
+
+const toEndOfDay = (date) => {
+        const d = new Date(date);
+        d.setHours(23, 59, 59, 999);
+        return d;
+};
+
+const parseListParam = (value) => {
+        if (!value) return [];
+        return value
+                .split(",")
+                .map((item) => item.trim())
+                .filter(Boolean);
+};
+
+const calculateDuration = (start, end) => Math.max(end.getTime() - start.getTime(), 0);
+
+const reduceProductsQuantityExpression = {
+        $reduce: {
+                input: { $ifNull: ["$products", []] },
+                initialValue: 0,
+                in: {
+                        $add: ["$$value", { $ifNull: ["$$this.quantity", 0] }],
+                },
+        },
+};
+
+const buildBucketExpressions = (interval) => {
+        if (interval === "week") {
+                return {
+                        label: {
+                                $concat: [
+                                        { $toString: { $isoWeekYear: "$order.orderDate" } },
+                                        "-W",
+                                        {
+                                                $cond: [
+                                                        {
+                                                                $lt: [{ $isoWeek: "$order.orderDate" }, 10],
+                                                        },
+                                                        {
+                                                                $concat: [
+                                                                        "0",
+                                                                        { $toString: { $isoWeek: "$order.orderDate" } },
+                                                                ],
+                                                        },
+                                                        { $toString: { $isoWeek: "$order.orderDate" } },
+                                                ],
+                                        },
+                                ],
+                        },
+                        sortKey: {
+                                $dateFromParts: {
+                                        isoWeekYear: { $isoWeekYear: "$order.orderDate" },
+                                        isoWeek: { $isoWeek: "$order.orderDate" },
+                                        isoDayOfWeek: 1,
+                                },
+                        },
+                };
+        }
+
+        if (interval === "month") {
+                return {
+                        label: {
+                                $dateToString: {
+                                        format: "%Y-%m",
+                                        date: "$order.orderDate",
+                                },
+                        },
+                        sortKey: {
+                                $dateFromParts: {
+                                        year: { $year: "$order.orderDate" },
+                                        month: { $month: "$order.orderDate" },
+                                        day: 1,
+                                },
+                        },
+                };
+        }
+
+        return {
+                label: {
+                        $dateToString: {
+                                format: "%Y-%m-%d",
+                                date: "$order.orderDate",
+                        },
+                },
+                sortKey: "$order.orderDate",
+        };
+};
+
+const buildSummaryPipeline = ({
+        startDate,
+        endDate,
+        statuses,
+        paymentMethods,
+        productIdFilter,
+        sellerIdFilter,
+}) => {
+        const matchStage = {
+                createdAt: { $gte: startDate, $lte: endDate },
+        };
+
+        if (sellerIdFilter?.length) {
+                matchStage.sellerId = { $in: sellerIdFilter };
+        }
+
+        if (statuses.length) {
+                matchStage.status = { $in: statuses };
+        }
+
+        if (productIdFilter) {
+                matchStage["products.productId"] = { $in: productIdFilter };
+        }
+
+        const pipeline = [
+                { $match: matchStage },
+                {
+                        $lookup: {
+                                from: "orders",
+                                localField: "orderId",
+                                foreignField: "_id",
+                                as: "order",
+                        },
+                },
+                { $unwind: "$order" },
+                {
+                        $match: {
+                                "order.orderDate": { $gte: startDate, $lte: endDate },
+                        },
+                },
+        ];
+
+        if (paymentMethods.length) {
+                pipeline.push({
+                        $match: { "order.paymentMethod": { $in: paymentMethods } },
+                });
+        }
+
+        pipeline.push({
+                $group: {
+                        _id: null,
+                        totalOrders: { $sum: 1 },
+                        totalRevenue: {
+                                $sum: { $ifNull: ["$totalAmount", 0] },
+                        },
+                        totalUnits: { $sum: reduceProductsQuantityExpression },
+                },
+        });
+
+        pipeline.push({
+                $project: {
+                        _id: 0,
+                        totalOrders: 1,
+                        totalRevenue: 1,
+                        totalUnits: 1,
+                },
+        });
+
+        return pipeline;
+};
+
+const buildSellerOptions = (sellers) =>
+        sellers.map((seller) => ({
+                value: String(seller._id),
+                label:
+                        [seller.firstName, seller.lastName]
+                                .filter(Boolean)
+                                .join(" ") ||
+                        seller.company?.brandName ||
+                        seller.company?.companyName ||
+                        seller.email ||
+                        seller.mobile ||
+                        String(seller._id),
+                status: seller.status,
+        }));
+
+export async function GET(request) {
+        try {
+                await dbConnect();
+
+                const cookieStore = await cookies();
+                const token = cookieStore.get("admin_token")?.value;
+
+                if (!token) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                let decoded;
+                try {
+                        decoded = verifyToken(token);
+                } catch (error) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                if (!decoded?.id) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                const url = new URL(request.url);
+                const params = url.searchParams;
+
+                const now = new Date();
+                const defaultEnd = toEndOfDay(now);
+                const defaultStart = toStartOfDay(
+                        new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000)
+                );
+
+                const startDateParam = params.get("startDate");
+                const endDateParam = params.get("endDate");
+                const intervalParam = params.get("interval")?.toLowerCase();
+
+                let startDate = startDateParam ? new Date(startDateParam) : defaultStart;
+                let endDate = endDateParam ? new Date(endDateParam) : defaultEnd;
+
+                if (Number.isNaN(startDate.getTime())) {
+                        startDate = defaultStart;
+                }
+
+                if (Number.isNaN(endDate.getTime())) {
+                        endDate = defaultEnd;
+                }
+
+                if (startDate > endDate) {
+                        const temp = startDate;
+                        startDate = endDate;
+                        endDate = temp;
+                }
+
+                startDate = toStartOfDay(startDate);
+                endDate = toEndOfDay(endDate);
+
+                const interval = intervalOptions.has(intervalParam)
+                        ? intervalParam
+                        : DEFAULT_INTERVAL;
+
+                const statuses = parseListParam(params.get("status"));
+                const paymentMethods = parseListParam(params.get("paymentMethods"));
+                const categories = parseListParam(params.get("categories"));
+                const sellerParams = parseListParam(params.get("sellers"));
+
+                const sellerIdFilter = sellerParams
+                        .map((id) => {
+                                if (!mongoose.Types.ObjectId.isValid(id)) return null;
+                                return new mongoose.Types.ObjectId(id);
+                        })
+                        .filter(Boolean);
+
+                let productIdFilter = null;
+                if (categories.length) {
+                        const productDocs = await Product.find({
+                                category: { $in: categories },
+                        }).select("_id");
+
+                        if (productDocs.length) {
+                                productIdFilter = productDocs.map((doc) => doc._id);
+                        } else {
+                                productIdFilter = [];
+                        }
+                }
+
+                const matchStage = {
+                        createdAt: { $gte: startDate, $lte: endDate },
+                };
+
+                if (sellerIdFilter.length) {
+                        matchStage.sellerId = { $in: sellerIdFilter };
+                }
+
+                if (statuses.length) {
+                        matchStage.status = { $in: statuses };
+                }
+
+                if (Array.isArray(productIdFilter)) {
+                        matchStage["products.productId"] = { $in: productIdFilter };
+                }
+
+                const bucketExpressions = buildBucketExpressions(interval);
+
+                const basePipeline = [
+                        { $match: matchStage },
+                        {
+                                $lookup: {
+                                        from: "orders",
+                                        localField: "orderId",
+                                        foreignField: "_id",
+                                        as: "order",
+                                },
+                        },
+                        { $unwind: "$order" },
+                        {
+                                $match: {
+                                        "order.orderDate": { $gte: startDate, $lte: endDate },
+                                },
+                        },
+                ];
+
+                if (paymentMethods.length) {
+                        basePipeline.push({
+                                $match: { "order.paymentMethod": { $in: paymentMethods } },
+                        });
+                }
+
+                basePipeline.push({
+                        $addFields: {
+                                paymentMethod: {
+                                        $ifNull: ["$order.paymentMethod", "unknown"],
+                                },
+                                orderDate: "$order.orderDate",
+                                customerId: "$order.userId",
+                                unitCount: reduceProductsQuantityExpression,
+                        },
+                });
+
+                basePipeline.push({
+                        $lookup: {
+                                from: "products",
+                                let: { productIds: "$products.productId" },
+                                pipeline: [
+                                        {
+                                                $match: {
+                                                        $expr: {
+                                                                $in: ["$_id", "$$productIds"],
+                                                        },
+                                                },
+                                        },
+                                        {
+                                                $project: {
+                                                        category: 1,
+                                                        title: "$title",
+                                                },
+                                        },
+                                ],
+                                as: "productInfo",
+                        },
+                });
+
+                basePipeline.push({
+                        $addFields: {
+                                categories: {
+                                        $map: {
+                                                input: { $ifNull: ["$productInfo", []] },
+                                                as: "info",
+                                                in: {
+                                                        $ifNull: ["$$info.category", "Uncategorized"],
+                                                },
+                                        },
+                                },
+                        },
+                });
+
+                const analyticsPipeline = [
+                        ...basePipeline,
+                        {
+                                $facet: {
+                                        summary: [
+                                                {
+                                                        $group: {
+                                                                _id: null,
+                                                                totalOrders: { $sum: 1 },
+                                                                totalRevenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                                totalUnits: { $sum: "$unitCount" },
+                                                                uniqueCustomers: {
+                                                                        $addToSet: {
+                                                                                $ifNull: [
+                                                                                        "$customerId",
+                                                                                        "unknown",
+                                                                                ],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                totalOrders: 1,
+                                                                totalRevenue: 1,
+                                                                totalUnits: 1,
+                                                                uniqueCustomers: {
+                                                                        $cond: [
+                                                                                {
+                                                                                        $isArray:
+                                                                                                "$uniqueCustomers",
+                                                                                },
+                                                                                { $size: "$uniqueCustomers" },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                                averageOrderValue: {
+                                                                        $cond: [
+                                                                                { $gt: ["$totalOrders", 0] },
+                                                                                {
+                                                                                        $divide: [
+                                                                                                "$totalRevenue",
+                                                                                                "$totalOrders",
+                                                                                        ],
+                                                                                },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                        },
+                                                },
+                                        ],
+                                        ordersOverTime: [
+                                                {
+                                                        $addFields: {
+                                                                bucketLabel: bucketExpressions.label,
+                                                                bucketSortKey: bucketExpressions.sortKey,
+                                                        },
+                                                },
+                                                {
+                                                        $group: {
+                                                                _id: "$bucketLabel",
+                                                                sortKey: {
+                                                                        $first: "$bucketSortKey",
+                                                                },
+                                                                orders: { $sum: 1 },
+                                                                revenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                                units: { $sum: "$unitCount" },
+                                                        },
+                                                },
+                                                { $sort: { sortKey: 1 } },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                label: "$_id",
+                                                                orders: 1,
+                                                                revenue: 1,
+                                                                units: 1,
+                                                                averageOrderValue: {
+                                                                        $cond: [
+                                                                                { $gt: ["$orders", 0] },
+                                                                                {
+                                                                                        $divide: [
+                                                                                                "$revenue",
+                                                                                                "$orders",
+                                                                                        ],
+                                                                                },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                        },
+                                                },
+                                        ],
+                                        statusDistribution: [
+                                                {
+                                                        $group: {
+                                                                _id: {
+                                                                        $ifNull: ["$status", "unknown"],
+                                                                },
+                                                                count: { $sum: 1 },
+                                                                revenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                { $sort: { count: -1 } },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                status: "$_id",
+                                                                count: 1,
+                                                                revenue: 1,
+                                                        },
+                                                },
+                                        ],
+                                        paymentMethods: [
+                                                {
+                                                        $group: {
+                                                                _id: "$paymentMethod",
+                                                                count: { $sum: 1 },
+                                                                revenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                { $sort: { revenue: -1 } },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                method: "$_id",
+                                                                count: 1,
+                                                                revenue: 1,
+                                                        },
+                                                },
+                                        ],
+                                        topProducts: [
+                                                { $unwind: "$products" },
+                                                {
+                                                        $group: {
+                                                                _id: "$products.productId",
+                                                                productName: {
+                                                                        $first: {
+                                                                                $ifNull: [
+                                                                                        "$products.productName",
+                                                                                        "Unknown product",
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                totalUnits: {
+                                                                        $sum: {
+                                                                                $ifNull: [
+                                                                                        "$products.quantity",
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                totalRevenue: {
+                                                                        $sum: {
+                                                                                $ifNull: [
+                                                                                        "$products.totalPrice",
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                { $sort: { totalRevenue: -1 } },
+                                                { $limit: 10 },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                productId: {
+                                                                        $convert: {
+                                                                                input: "$_id",
+                                                                                to: "string",
+                                                                                onError: null,
+                                                                                onNull: null,
+                                                                        },
+                                                                },
+                                                                productName: 1,
+                                                                totalUnits: 1,
+                                                                totalRevenue: 1,
+                                                        },
+                                                },
+                                        ],
+                                        categoryPerformance: [
+                                                { $unwind: "$products" },
+                                                {
+                                                        $lookup: {
+                                                                from: "products",
+                                                                localField: "products.productId",
+                                                                foreignField: "_id",
+                                                                as: "productDetails",
+                                                        },
+                                                },
+                                                {
+                                                        $unwind: {
+                                                                path: "$productDetails",
+                                                                preserveNullAndEmptyArrays: true,
+                                                        },
+                                                },
+                                                {
+                                                        $group: {
+                                                                _id: {
+                                                                        $ifNull: [
+                                                                                "$productDetails.category",
+                                                                                "Uncategorized",
+                                                                        ],
+                                                                },
+                                                                totalRevenue: {
+                                                                        $sum: {
+                                                                                $ifNull: [
+                                                                                        "$products.totalPrice",
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                totalUnits: {
+                                                                        $sum: {
+                                                                                $ifNull: [
+                                                                                        "$products.quantity",
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                orders: {
+                                                                        $addToSet: "$_id",
+                                                                },
+                                                        },
+                                                },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                category: "$_id",
+                                                                totalRevenue: 1,
+                                                                totalUnits: 1,
+                                                                orderCount: {
+                                                                        $cond: [
+                                                                                {
+                                                                                        $isArray: "$orders",
+                                                                                },
+                                                                                { $size: "$orders" },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                        },
+                                                },
+                                                { $sort: { totalRevenue: -1 } },
+                                        ],
+                                        sellerPerformance: [
+                                                {
+                                                        $group: {
+                                                                _id: {
+                                                                        sellerId: "$sellerId",
+                                                                        status: "$status",
+                                                                },
+                                                                revenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                                orders: { $sum: 1 },
+                                                                units: { $sum: "$unitCount" },
+                                                        },
+                                                },
+                                                {
+                                                        $group: {
+                                                                _id: "$_id.sellerId",
+                                                                totalRevenue: { $sum: "$revenue" },
+                                                                totalOrders: { $sum: "$orders" },
+                                                                totalUnits: { $sum: "$units" },
+                                                                statusBreakdown: {
+                                                                        $push: {
+                                                                                status: {
+                                                                                        $ifNull: [
+                                                                                                "$_id.status",
+                                                                                                "unknown",
+                                                                                        ],
+                                                                                },
+                                                                                orders: "$orders",
+                                                                                revenue: "$revenue",
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                {
+                                                        $lookup: {
+                                                                from: "users",
+                                                                localField: "_id",
+                                                                foreignField: "_id",
+                                                                as: "seller",
+                                                        },
+                                                },
+                                                {
+                                                        $unwind: {
+                                                                path: "$seller",
+                                                                preserveNullAndEmptyArrays: true,
+                                                        },
+                                                },
+                                                {
+                                                        $lookup: {
+                                                                from: "companies",
+                                                                localField: "seller.company",
+                                                                foreignField: "_id",
+                                                                as: "company",
+                                                        },
+                                                },
+                                                {
+                                                        $unwind: {
+                                                                path: "$company",
+                                                                preserveNullAndEmptyArrays: true,
+                                                        },
+                                                },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                sellerId: {
+                                                                        $convert: {
+                                                                                input: "$_id",
+                                                                                to: "string",
+                                                                                onError: null,
+                                                                                onNull: null,
+                                                                        },
+                                                                },
+                                                                name: {
+                                                                        $concat: [
+                                                                                { $ifNull: ["$seller.firstName", ""] },
+                                                                                " ",
+                                                                                { $ifNull: ["$seller.lastName", ""] },
+                                                                        ],
+                                                                },
+                                                                email: "$seller.email",
+                                                                phone: "$seller.mobile",
+                                                                companyName: "$company.companyName",
+                                                                brandName: "$company.brandName",
+                                                                status: "$seller.status",
+                                                                totalRevenue: 1,
+                                                                totalOrders: 1,
+                                                                totalUnits: 1,
+                                                                averageOrderValue: {
+                                                                        $cond: [
+                                                                                { $gt: ["$totalOrders", 0] },
+                                                                                {
+                                                                                        $divide: [
+                                                                                                "$totalRevenue",
+                                                                                                "$totalOrders",
+                                                                                        ],
+                                                                                },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                                statusBreakdown: 1,
+                                                        },
+                                                },
+                                                { $sort: { totalRevenue: -1 } },
+                                        ],
+                                        customerSegments: [
+                                                {
+                                                        $group: {
+                                                                _id: "$customerId",
+                                                                orders: { $sum: 1 },
+                                                                firstOrder: { $min: "$orderDate" },
+                                                                lastOrder: { $max: "$orderDate" },
+                                                                totalSpent: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                {
+                                                        $group: {
+                                                                _id: null,
+                                                                totalCustomers: { $sum: 1 },
+                                                                repeatCustomers: {
+                                                                        $sum: {
+                                                                                $cond: [
+                                                                                        { $gt: ["$orders", 1] },
+                                                                                        1,
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                newCustomers: {
+                                                                        $sum: {
+                                                                                $cond: [
+                                                                                        {
+                                                                                                $and: [
+                                                                                                        {
+                                                                                                                $gte: [
+                                                                                                                        "$firstOrder",
+                                                                                                                        startDate,
+                                                                                                                ],
+                                                                                                        },
+                                                                                                        {
+                                                                                                                $lte: [
+                                                                                                                        "$firstOrder",
+                                                                                                                        endDate,
+                                                                                                                ],
+                                                                                                        },
+                                                                                                        {
+                                                                                                                $eq: [
+                                                                                                                        "$orders",
+                                                                                                                        1,
+                                                                                                                ],
+                                                                                                        },
+                                                                                                ],
+                                                                                        },
+                                                                                        1,
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                returningCustomers: {
+                                                                        $sum: {
+                                                                                $cond: [
+                                                                                        { $gt: ["$orders", 1] },
+                                                                                        1,
+                                                                                        0,
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                avgOrderFrequency: { $avg: "$orders" },
+                                                                customerLifetimeValue: {
+                                                                        $avg: "$totalSpent",
+                                                                },
+                                                        },
+                                                },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                totalCustomers: 1,
+                                                                repeatCustomers: 1,
+                                                                newCustomers: 1,
+                                                                returningCustomers: 1,
+                                                                avgOrderFrequency: {
+                                                                        $ifNull: ["$avgOrderFrequency", 0],
+                                                                },
+                                                                customerLifetimeValue: {
+                                                                        $ifNull: [
+                                                                                "$customerLifetimeValue",
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                        },
+                                                },
+                                        ],
+                                        ordersReport: [
+                                                {
+                                                        $project: {
+                                                                _id: 1,
+                                                                orderNumber: "$order.orderNumber",
+                                                                orderDate: "$order.orderDate",
+                                                                status: "$status",
+                                                                paymentMethod: "$paymentMethod",
+                                                                totalAmount: {
+                                                                        $ifNull: ["$totalAmount", 0],
+                                                                },
+                                                                units: "$unitCount",
+                                                                categories: {
+                                                                        $ifNull: ["$categories", []],
+                                                                },
+                                                        },
+                                                },
+                                                { $sort: { orderDate: -1 } },
+                                                { $limit: 200 },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                id: {
+                                                                        $convert: {
+                                                                                input: "$_id",
+                                                                                to: "string",
+                                                                                onError: null,
+                                                                                onNull: null,
+                                                                        },
+                                                                },
+                                                                orderNumber: 1,
+                                                                orderDate: 1,
+                                                                status: 1,
+                                                                paymentMethod: 1,
+                                                                totalAmount: 1,
+                                                                units: 1,
+                                                                categories: 1,
+                                                        },
+                                                },
+                                        ],
+                                        topCustomers: [
+                                                {
+                                                        $match: {
+                                                                customerId: { $ne: null },
+                                                        },
+                                                },
+                                                {
+                                                        $group: {
+                                                                _id: "$customerId",
+                                                                totalRevenue: {
+                                                                        $sum: {
+                                                                                $ifNull: ["$totalAmount", 0],
+                                                                        },
+                                                                },
+                                                                orders: { $sum: 1 },
+                                                                units: { $sum: "$unitCount" },
+                                                                lastOrder: { $max: "$orderDate" },
+                                                        },
+                                                },
+                                                { $sort: { totalRevenue: -1 } },
+                                                { $limit: 15 },
+                                                {
+                                                        $lookup: {
+                                                                from: "users",
+                                                                localField: "_id",
+                                                                foreignField: "_id",
+                                                                as: "customer",
+                                                        },
+                                                },
+                                                {
+                                                        $unwind: {
+                                                                path: "$customer",
+                                                                preserveNullAndEmptyArrays: true,
+                                                        },
+                                                },
+                                                {
+                                                        $project: {
+                                                                _id: 0,
+                                                                customerId: {
+                                                                        $convert: {
+                                                                                input: "$_id",
+                                                                                to: "string",
+                                                                                onError: null,
+                                                                                onNull: null,
+                                                                        },
+                                                                },
+                                                                totalRevenue: 1,
+                                                                orders: 1,
+                                                                units: 1,
+                                                                lastOrder: 1,
+                                                                firstName: "$customer.firstName",
+                                                                lastName: "$customer.lastName",
+                                                                email: "$customer.email",
+                                                                phone: "$customer.mobile",
+                                                        },
+                                                },
+                                        ],
+                                },
+                        },
+                ];
+
+                const [analytics] = await SubOrder.aggregate(analyticsPipeline);
+
+                const summary = analytics?.summary?.[0] || {
+                        totalOrders: 0,
+                        totalRevenue: 0,
+                        totalUnits: 0,
+                        uniqueCustomers: 0,
+                        averageOrderValue: 0,
+                };
+
+                const customerSegments = analytics?.customerSegments?.[0] || {
+                        totalCustomers: 0,
+                        repeatCustomers: 0,
+                        newCustomers: 0,
+                        returningCustomers: 0,
+                        avgOrderFrequency: 0,
+                        customerLifetimeValue: 0,
+                };
+
+                const sellerPerformance = (analytics?.sellerPerformance || []).map(
+                        (seller) => {
+                                const trimmedName = seller.name?.trim() || "";
+                                const displayName =
+                                        trimmedName ||
+                                        seller.brandName ||
+                                        seller.companyName ||
+                                        seller.email ||
+                                        seller.phone ||
+                                        seller.sellerId;
+
+                                return {
+                                        ...seller,
+                                        name: trimmedName,
+                                        displayName,
+                                };
+                        }
+                );
+
+                const previousRangeDuration = calculateDuration(startDate, endDate) || 1;
+                const prevEnd = new Date(startDate.getTime() - 1);
+                const prevStart = new Date(prevEnd.getTime() - previousRangeDuration);
+
+                const previousSummaryPipeline = buildSummaryPipeline({
+                        startDate: prevStart,
+                        endDate: prevEnd,
+                        statuses,
+                        paymentMethods,
+                        productIdFilter,
+                        sellerIdFilter,
+                });
+
+                const [previousSummary] = await SubOrder.aggregate(previousSummaryPipeline);
+
+                const previous =
+                        previousSummary || {
+                                totalOrders: 0,
+                                totalRevenue: 0,
+                                totalUnits: 0,
+                        };
+
+                const growth = {
+                        revenue:
+                                previous.totalRevenue > 0
+                                        ? ((summary.totalRevenue - previous.totalRevenue) /
+                                                  previous.totalRevenue) *
+                                          100
+                                        : summary.totalRevenue > 0
+                                          ? 100
+                                          : 0,
+                        orders:
+                                previous.totalOrders > 0
+                                        ? ((summary.totalOrders - previous.totalOrders) /
+                                                  previous.totalOrders) *
+                                          100
+                                        : summary.totalOrders > 0
+                                          ? 100
+                                          : 0,
+                        units:
+                                previous.totalUnits > 0
+                                        ? ((summary.totalUnits - previous.totalUnits) /
+                                                  previous.totalUnits) *
+                                          100
+                                        : summary.totalUnits > 0
+                                          ? 100
+                                          : 0,
+                };
+
+                const [statusOptions, paymentOptionsRaw, categoryOptions, sellersRaw] =
+                        await Promise.all([
+                                SubOrder.distinct("status"),
+                                SubOrder.aggregate([
+                                        {
+                                                $lookup: {
+                                                        from: "orders",
+                                                        localField: "orderId",
+                                                        foreignField: "_id",
+                                                        as: "order",
+                                                },
+                                        },
+                                        { $unwind: "$order" },
+                                        {
+                                                $group: { _id: "$order.paymentMethod" },
+                                        },
+                                        {
+                                                $project: {
+                                                        _id: 0,
+                                                        value: { $ifNull: ["$_id", "unknown"] },
+                                                },
+                                        },
+                                ]).then((items) => items.map((item) => item.value)),
+                                Product.distinct("category"),
+                                User.find({ userType: "seller" })
+                                        .populate({
+                                                path: "company",
+                                                select: "companyName brandName",
+                                        })
+                                        .select(
+                                                "firstName lastName email mobile status company"
+                                        )
+                                        .lean(),
+                        ]);
+
+                const sellerOptions = buildSellerOptions(sellersRaw || []);
+
+                return NextResponse.json({
+                        success: true,
+                        data: {
+                                summary,
+                                ordersOverTime: analytics?.ordersOverTime || [],
+                                statusDistribution: analytics?.statusDistribution || [],
+                                paymentMethods: analytics?.paymentMethods || [],
+                                topProducts: analytics?.topProducts || [],
+                                categoryPerformance: analytics?.categoryPerformance || [],
+                                sellerPerformance,
+                                customerSegments,
+                                reports: {
+                                        orders: analytics?.ordersReport || [],
+                                        sellers: sellerPerformance,
+                                        customers: analytics?.topCustomers || [],
+                                },
+                                availableFilters: {
+                                        statuses: statusOptions,
+                                        paymentMethods: paymentOptionsRaw,
+                                        categories: categoryOptions,
+                                        sellers: sellerOptions,
+                                },
+                                meta: {
+                                        startDate,
+                                        endDate,
+                                        interval,
+                                },
+                                growth,
+                        },
+                });
+        } catch (error) {
+                console.error("Admin analytics error:", error);
+                return NextResponse.json(
+                        { success: false, message: "Failed to load analytics" },
+                        { status: 500 }
+                );
+        }
+}

--- a/components/AdminPanel/AdminSidebar.jsx
+++ b/components/AdminPanel/AdminSidebar.jsx
@@ -47,20 +47,26 @@ import {
         Palette,
         Cog,
         RotateCcw,
+        BarChart3,
 } from "lucide-react";
 import Logo from "@/public/SafetyLogo.png";
 import { useIsAuthenticated } from "@/store/adminAuthStore.js";
 
 const menuItems = [
-	{
-		title: "Dashboard",
-		icon: LayoutDashboard,
-		href: "/admin/dashboard",
-	},
-	{
-		title: "Catalog",
-		icon: Package,
-		items: [
+        {
+                title: "Dashboard",
+                icon: LayoutDashboard,
+                href: "/admin/dashboard",
+        },
+        {
+                title: "Analytics",
+                icon: BarChart3,
+                href: "/admin/analytics",
+        },
+        {
+                title: "Catalog",
+                icon: Package,
+                items: [
 			{ title: "Products", href: "/admin/catalog/products", icon: FolderOpen },
 			{ title: "Categories", href: "/admin/catalog/categories", icon: Tags },
 			// { title: "Attributes", href: "/admin/catalog/attributes", icon: Layers },

--- a/components/AdminPanel/Analytics/AdminAnalytics.jsx
+++ b/components/AdminPanel/Analytics/AdminAnalytics.jsx
@@ -1,0 +1,1133 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import {
+        ArrowUpRight,
+        BarChart3,
+        CalendarDays,
+        Download,
+        Filter,
+        LineChart,
+        ListFilter,
+        RefreshCw,
+        ShoppingBag,
+        TrendingDown,
+        TrendingUp,
+        Users,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow,
+} from "@/components/ui/table";
+import {
+        DropdownMenu,
+        DropdownMenuCheckboxItem,
+        DropdownMenuContent,
+        DropdownMenuLabel,
+        DropdownMenuSeparator,
+        DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+
+import { useIsAuthenticated } from "@/store/adminAuthStore";
+import { toast } from "react-hot-toast";
+import {
+        useAdminAnalyticsStore,
+        useAdminAnalyticsFilters,
+        useAdminAnalyticsData,
+        useAdminAnalyticsLoading,
+        useAdminAnalyticsError,
+} from "@/store/adminAnalyticsStore";
+
+const ResponsiveContainer = dynamic(
+        () => import("recharts").then((mod) => mod.ResponsiveContainer),
+        { ssr: false }
+);
+const AreaChart = dynamic(() => import("recharts").then((mod) => mod.AreaChart), {
+        ssr: false,
+});
+const Area = dynamic(() => import("recharts").then((mod) => mod.Area), {
+        ssr: false,
+});
+const XAxis = dynamic(() => import("recharts").then((mod) => mod.XAxis), {
+        ssr: false,
+});
+const YAxis = dynamic(() => import("recharts").then((mod) => mod.YAxis), {
+        ssr: false,
+});
+const Tooltip = dynamic(() => import("recharts").then((mod) => mod.Tooltip), {
+        ssr: false,
+});
+const CartesianGrid = dynamic(
+        () => import("recharts").then((mod) => mod.CartesianGrid),
+        { ssr: false }
+);
+
+const summaryCards = (data) => [
+        {
+                title: "Total revenue",
+                value: data.summary.totalRevenue,
+                prefix: "₹",
+                icon: LineChart,
+                change: data.growth.revenue,
+        },
+        {
+                title: "Total orders",
+                value: data.summary.totalOrders,
+                icon: ShoppingBag,
+                change: data.growth.orders,
+        },
+        {
+                title: "Units sold",
+                value: data.summary.totalUnits,
+                icon: BarChart3,
+                change: data.growth.units,
+        },
+        {
+                title: "Unique customers",
+                value: data.summary.uniqueCustomers,
+                icon: Users,
+                hideTrend: true,
+        },
+];
+
+const formatCurrency = (value) =>
+        typeof value === "number"
+                ? value.toLocaleString(undefined, {
+                          style: "currency",
+                          currency: "INR",
+                          maximumFractionDigits: 0,
+                  })
+                : value;
+
+const trendIndicator = (change) => {
+        if (typeof change !== "number") {
+                return <span className="text-sm text-muted-foreground">—</span>;
+        }
+
+        if (change > 0) {
+                return (
+                        <span className="flex items-center text-sm font-medium text-emerald-600">
+                                <TrendingUp className="mr-1 h-4 w-4" />
+                                {change.toFixed(1)}%
+                        </span>
+                );
+        }
+
+        if (change < 0) {
+                return (
+                        <span className="flex items-center text-sm font-medium text-red-600">
+                                <TrendingDown className="mr-1 h-4 w-4" />
+                                {Math.abs(change).toFixed(1)}%
+                        </span>
+                );
+        }
+
+        return <span className="text-sm text-muted-foreground">0%</span>;
+};
+
+const buildActiveFilterChips = (filters, analytics) => {
+        const chips = [];
+        if (filters.statuses.length) {
+                chips.push(
+                        ...filters.statuses.map((status) => ({
+                                label: `Status: ${status}`,
+                                type: "statuses",
+                                value: status,
+                        }))
+                );
+        }
+
+        if (filters.paymentMethods.length) {
+                chips.push(
+                        ...filters.paymentMethods.map((method) => ({
+                                label: `Payment: ${method}`,
+                                type: "paymentMethods",
+                                value: method,
+                        }))
+                );
+        }
+
+        if (filters.categories.length) {
+                chips.push(
+                        ...filters.categories.map((category) => ({
+                                label: `Category: ${category}`,
+                                type: "categories",
+                                value: category,
+                        }))
+                );
+        }
+
+        if (filters.sellers.length) {
+                const sellerMap = new Map(
+                        (analytics.availableFilters.sellers || []).map((seller) => [
+                                seller.value,
+                                seller.label,
+                        ])
+                );
+
+                chips.push(
+                        ...filters.sellers.map((sellerId) => ({
+                                label: `Seller: ${sellerMap.get(sellerId) || sellerId}`,
+                                type: "sellers",
+                                value: sellerId,
+                        }))
+                );
+        }
+
+        return chips;
+};
+
+const useDownloadHandler = (getBlob, filename) =>
+        useCallback(() => {
+                const blob = getBlob();
+                if (!blob) {
+                        toast.error("No data available for export");
+                        return;
+                }
+
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+        }, [getBlob, filename, toast]);
+
+export default function AdminAnalytics() {
+        const router = useRouter();
+        const isAuthenticated = useIsAuthenticated();
+
+        const filters = useAdminAnalyticsFilters();
+        const analytics = useAdminAnalyticsData();
+        const loading = useAdminAnalyticsLoading();
+        const error = useAdminAnalyticsError();
+
+        const fetchAnalytics = useAdminAnalyticsStore((state) => state.fetchAnalytics);
+        const setFilter = useAdminAnalyticsStore((state) => state.setFilter);
+        const resetFilters = useAdminAnalyticsStore((state) => state.resetFilters);
+        const exportOrdersReport = useAdminAnalyticsStore(
+                (state) => state.exportOrdersReport
+        );
+        const exportSellerReport = useAdminAnalyticsStore(
+                (state) => state.exportSellerReport
+        );
+
+        useEffect(() => {
+                if (!isAuthenticated) {
+                        router.push("/admin/login");
+                }
+        }, [isAuthenticated, router]);
+
+        useEffect(() => {
+                if (isAuthenticated) {
+                        fetchAnalytics();
+                }
+        }, [fetchAnalytics, isAuthenticated]);
+
+        const activeFilters = useMemo(
+                () => buildActiveFilterChips(filters, analytics),
+                [filters, analytics]
+        );
+
+        const removeFilter = useCallback(
+                (type, value) => {
+                        setFilter(
+                                type,
+                                filters[type].filter((item) => item !== value)
+                        );
+                },
+                [filters, setFilter]
+        );
+
+        const toggleMultiSelect = useCallback(
+                (type, value) => {
+                        const current = new Set(filters[type]);
+                        if (current.has(value)) {
+                                current.delete(value);
+                        } else {
+                                current.add(value);
+                        }
+                        setFilter(type, Array.from(current));
+                },
+                [filters, setFilter]
+        );
+
+        const handleExportOrders = useDownloadHandler(
+                exportOrdersReport,
+                "orders-report.csv"
+        );
+
+        const handleExportSellers = useDownloadHandler(
+                exportSellerReport,
+                "seller-performance.csv"
+        );
+
+        const statusMax = useMemo(() => {
+                if (!analytics.statusDistribution?.length) {
+                        return 1;
+                }
+                return Math.max(
+                        ...analytics.statusDistribution.map((item) => item.count),
+                        1
+                );
+        }, [analytics.statusDistribution]);
+
+        const totalCustomers = useMemo(() => {
+                const total = analytics.customerSegments.totalCustomers || 0;
+                return total > 0 ? total : 1;
+        }, [analytics.customerSegments.totalCustomers]);
+
+        if (!isAuthenticated) {
+                return null;
+        }
+
+        return (
+                <div className="space-y-6">
+                        <motion.div
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.25 }}
+                                className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between"
+                        >
+                                <div className="space-y-2">
+                                        <h1 className="text-3xl font-bold text-gray-900">
+                                                Analytics &amp; reports
+                                        </h1>
+                                        <p className="text-gray-600 max-w-2xl">
+                                                Explore revenue trends, order performance, customer
+                                                insights, and seller-level intelligence for the entire
+                                                marketplace.
+                                        </p>
+                                </div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                        <Button
+                                                variant="outline"
+                                                onClick={handleExportOrders}
+                                                disabled={loading}
+                                        >
+                                                <Download className="mr-2 h-4 w-4" />
+                                                Export orders
+                                        </Button>
+                                        <Button
+                                                variant="outline"
+                                                onClick={handleExportSellers}
+                                                disabled={loading}
+                                        >
+                                                <Download className="mr-2 h-4 w-4" />
+                                                Export sellers
+                                        </Button>
+                                        <Button
+                                                onClick={() => fetchAnalytics()}
+                                                disabled={loading}
+                                                className="bg-orange-600 hover:bg-orange-700"
+                                        >
+                                                <RefreshCw
+                                                        className={`mr-2 h-4 w-4 ${
+                                                                loading ? "animate-spin" : ""
+                                                        }`}
+                                                />
+                                                Refresh
+                                        </Button>
+                                </div>
+                        </motion.div>
+
+                        <Card>
+                                <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                        <div className="flex items-center gap-2 text-muted-foreground">
+                                                <Filter className="h-4 w-4" />
+                                                <span className="text-sm font-medium uppercase tracking-wide">
+                                                        Filters
+                                                </span>
+                                        </div>
+                                        <div className="flex flex-wrap gap-2">
+                                                <Button variant="ghost" size="sm" onClick={resetFilters}>
+                                                        Reset
+                                                </Button>
+                                                <Button
+                                                        size="sm"
+                                                        onClick={() => fetchAnalytics()}
+                                                        disabled={loading}
+                                                >
+                                                        Apply changes
+                                                </Button>
+                                        </div>
+                                </CardHeader>
+                                <CardContent className="space-y-4">
+                                        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                                                <div className="space-y-2">
+                                                        <label className="text-sm font-medium text-muted-foreground">
+                                                                Start date
+                                                        </label>
+                                                        <div className="relative">
+                                                                <CalendarDays className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                                <Input
+                                                                        type="date"
+                                                                        className="pl-10"
+                                                                        value={filters.startDate}
+                                                                        onChange={(event) =>
+                                                                                setFilter(
+                                                                                        "startDate",
+                                                                                        event.target.value
+                                                                                )
+                                                                        }
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <label className="text-sm font-medium text-muted-foreground">
+                                                                End date
+                                                        </label>
+                                                        <div className="relative">
+                                                                <CalendarDays className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                                <Input
+                                                                        type="date"
+                                                                        className="pl-10"
+                                                                        value={filters.endDate}
+                                                                        onChange={(event) =>
+                                                                                setFilter(
+                                                                                        "endDate",
+                                                                                        event.target.value
+                                                                                )
+                                                                        }
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <label className="text-sm font-medium text-muted-foreground">
+                                                                Interval
+                                                        </label>
+                                                        <Select
+                                                                value={filters.interval}
+                                                                onValueChange={(value) =>
+                                                                        setFilter("interval", value)
+                                                                }
+                                                        >
+                                                                <SelectTrigger>
+                                                                        <SelectValue placeholder="Select interval" />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        <SelectItem value="day">Daily</SelectItem>
+                                                                        <SelectItem value="week">Weekly</SelectItem>
+                                                                        <SelectItem value="month">Monthly</SelectItem>
+                                                                </SelectContent>
+                                                        </Select>
+                                                </div>
+                                        </div>
+
+                                        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+                                                <DropdownMenu>
+                                                        <DropdownMenuTrigger asChild>
+                                                                <Button variant="outline" className="w-full justify-between">
+                                                                        <span className="flex items-center gap-2">
+                                                                                <ListFilter className="h-4 w-4" />
+                                                                                Status
+                                                                        </span>
+                                                                        <ArrowUpRight className="h-4 w-4" />
+                                                                </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent className="w-56">
+                                                                <DropdownMenuLabel>Order status</DropdownMenuLabel>
+                                                                <DropdownMenuSeparator />
+                                                                {(analytics.availableFilters.statuses || []).map(
+                                                                        (status) => (
+                                                                                <DropdownMenuCheckboxItem
+                                                                                        key={status}
+                                                                                        checked={filters.statuses.includes(status)}
+                                                                                        onCheckedChange={() =>
+                                                                                                toggleMultiSelect(
+                                                                                                        "statuses",
+                                                                                                        status
+                                                                                                )
+                                                                                        }
+                                                                                >
+                                                                                        {status}
+                                                                                </DropdownMenuCheckboxItem>
+                                                                        )
+                                                                )}
+                                                        </DropdownMenuContent>
+                                                </DropdownMenu>
+
+                                                <DropdownMenu>
+                                                        <DropdownMenuTrigger asChild>
+                                                                <Button variant="outline" className="w-full justify-between">
+                                                                        <span className="flex items-center gap-2">
+                                                                                <ListFilter className="h-4 w-4" />
+                                                                                Payment methods
+                                                                        </span>
+                                                                        <ArrowUpRight className="h-4 w-4" />
+                                                                </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent className="w-60">
+                                                                <DropdownMenuLabel>Payment methods</DropdownMenuLabel>
+                                                                <DropdownMenuSeparator />
+                                                                {(analytics.availableFilters.paymentMethods || []).map(
+                                                                        (method) => (
+                                                                                <DropdownMenuCheckboxItem
+                                                                                        key={method}
+                                                                                        checked={filters.paymentMethods.includes(
+                                                                                                method
+                                                                                        )}
+                                                                                        onCheckedChange={() =>
+                                                                                                toggleMultiSelect(
+                                                                                                        "paymentMethods",
+                                                                                                        method
+                                                                                                )
+                                                                                        }
+                                                                                >
+                                                                                        {method}
+                                                                                </DropdownMenuCheckboxItem>
+                                                                        )
+                                                                )}
+                                                        </DropdownMenuContent>
+                                                </DropdownMenu>
+
+                                                <DropdownMenu>
+                                                        <DropdownMenuTrigger asChild>
+                                                                <Button variant="outline" className="w-full justify-between">
+                                                                        <span className="flex items-center gap-2">
+                                                                                <ListFilter className="h-4 w-4" />
+                                                                                Categories
+                                                                        </span>
+                                                                        <ArrowUpRight className="h-4 w-4" />
+                                                                </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent className="w-60">
+                                                                <DropdownMenuLabel>Categories</DropdownMenuLabel>
+                                                                <DropdownMenuSeparator />
+                                                                {(analytics.availableFilters.categories || []).map(
+                                                                        (category) => (
+                                                                                <DropdownMenuCheckboxItem
+                                                                                        key={category}
+                                                                                        checked={filters.categories.includes(
+                                                                                                category
+                                                                                        )}
+                                                                                        onCheckedChange={() =>
+                                                                                                toggleMultiSelect(
+                                                                                                        "categories",
+                                                                                                        category
+                                                                                                )
+                                                                                        }
+                                                                                >
+                                                                                        {category}
+                                                                                </DropdownMenuCheckboxItem>
+                                                                        )
+                                                                )}
+                                                        </DropdownMenuContent>
+                                                </DropdownMenu>
+
+                                                <DropdownMenu>
+                                                        <DropdownMenuTrigger asChild>
+                                                                <Button variant="outline" className="w-full justify-between">
+                                                                        <span className="flex items-center gap-2">
+                                                                                <ListFilter className="h-4 w-4" />
+                                                                                Sellers
+                                                                        </span>
+                                                                        <ArrowUpRight className="h-4 w-4" />
+                                                                </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent className="w-64">
+                                                                <DropdownMenuLabel>Sellers</DropdownMenuLabel>
+                                                                <DropdownMenuSeparator />
+                                                                {(analytics.availableFilters.sellers || []).map(
+                                                                        (seller) => (
+                                                                                <DropdownMenuCheckboxItem
+                                                                                        key={seller.value}
+                                                                                        checked={filters.sellers.includes(
+                                                                                                seller.value
+                                                                                        )}
+                                                                                        onCheckedChange={() =>
+                                                                                                toggleMultiSelect(
+                                                                                                        "sellers",
+                                                                                                        seller.value
+                                                                                                )
+                                                                                        }
+                                                                                >
+                                                                                        <div className="flex flex-col">
+                                                                                                <span className="text-sm font-medium">
+                                                                                                        {seller.label}
+                                                                                                </span>
+                                                                                                <span className="text-xs text-muted-foreground">
+                                                                                                        {seller.status || ""}
+                                                                                                </span>
+                                                                                        </div>
+                                                                                </DropdownMenuCheckboxItem>
+                                                                        )
+                                                                )}
+                                                        </DropdownMenuContent>
+                                                </DropdownMenu>
+                                        </div>
+
+                                        {activeFilters.length > 0 && (
+                                                <div className="flex flex-wrap gap-2">
+                                                        {activeFilters.map((chip) => (
+                                                                <Badge
+                                                                        key={`${chip.type}-${chip.value}`}
+                                                                        variant="secondary"
+                                                                        className="flex items-center gap-1 cursor-pointer"
+                                                                        onClick={() =>
+                                                                                removeFilter(
+                                                                                        chip.type,
+                                                                                        chip.value
+                                                                                )
+                                                                        }
+                                                                >
+                                                                        {chip.label}
+                                                                        <span className="text-xs">×</span>
+                                                                </Badge>
+                                                        ))}
+                                                </div>
+                                        )}
+                                </CardContent>
+                        </Card>
+
+                        {error && (
+                                <Card className="border-red-200 bg-red-50">
+                                        <CardContent className="py-6 text-red-700">
+                                                <div className="flex items-center justify-between">
+                                                        <div>
+                                                                <p className="font-medium">{error}</p>
+                                                                <p className="text-sm text-red-600/80">
+                                                                        Try adjusting your filters or refresh the page.
+                                                                </p>
+                                                        </div>
+                                                        <Button onClick={() => fetchAnalytics()} size="sm">
+                                                                Retry
+                                                        </Button>
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        )}
+
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                                {summaryCards(analytics).map((card) => (
+                                        <Card key={card.title}>
+                                                <CardContent className="p-6">
+                                                        <div className="flex items-start justify-between">
+                                                                <div className="space-y-1">
+                                                                        <p className="text-sm font-medium text-muted-foreground">
+                                                                                {card.title}
+                                                                        </p>
+                                                                        <p className="text-2xl font-bold">
+                                                                                {card.prefix
+                                                                                        ? formatCurrency(card.value)
+                                                                                        : card.value?.toLocaleString?.() ??
+                                                                                          card.value}
+                                                                        </p>
+                                                                </div>
+                                                                <card.icon className="h-8 w-8 text-orange-500" />
+                                                        </div>
+                                                        {!card.hideTrend && (
+                                                                <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+                                                                        <span>vs previous period</span>
+                                                                        {trendIndicator(card.change)}
+                                                                </div>
+                                                        )}
+                                                </CardContent>
+                                        </Card>
+                                ))}
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+                                <Card className="xl:col-span-2">
+                                        <CardHeader>
+                                                <CardTitle className="flex items-center gap-2">
+                                                        <LineChart className="h-5 w-5 text-orange-500" />
+                                                        Orders &amp; revenue over time
+                                                </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="h-[320px]">
+                                                <ResponsiveContainer width="100%" height="100%">
+                                                        <AreaChart data={analytics.ordersOverTime}>
+                                                                <defs>
+                                                                        <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
+                                                                                <stop offset="5%" stopColor="#f97316" stopOpacity={0.4} />
+                                                                                <stop offset="95%" stopColor="#f97316" stopOpacity={0} />
+                                                                        </linearGradient>
+                                                                        <linearGradient id="colorOrders" x1="0" y1="0" x2="0" y2="1">
+                                                                                <stop offset="5%" stopColor="#6366f1" stopOpacity={0.4} />
+                                                                                <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                                                                        </linearGradient>
+                                                                </defs>
+                                                                <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                                                                <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                                                                <YAxis tickLine={false} axisLine={false} />
+                                                                <Tooltip
+                                                                        formatter={(value, key) => {
+                                                                                if (key === "revenue") {
+                                                                                        return [
+                                                                                                formatCurrency(value),
+                                                                                                "Revenue",
+                                                                                        ];
+                                                                                }
+                                                                                if (key === "orders") {
+                                                                                        return [value, "Orders"];
+                                                                                }
+                                                                                if (key === "units") {
+                                                                                        return [value, "Units"];
+                                                                                }
+                                                                                return [value, key];
+                                                                        }}
+                                                                />
+                                                                <Area
+                                                                        type="monotone"
+                                                                        dataKey="revenue"
+                                                                        stroke="#f97316"
+                                                                        fill="url(#colorRevenue)"
+                                                                        strokeWidth={2}
+                                                                />
+                                                                <Area
+                                                                        type="monotone"
+                                                                        dataKey="orders"
+                                                                        stroke="#6366f1"
+                                                                        fill="url(#colorOrders)"
+                                                                        strokeWidth={2}
+                                                                />
+                                                        </AreaChart>
+                                                </ResponsiveContainer>
+                                        </CardContent>
+                                </Card>
+
+                                <div className="space-y-6">
+                                        <Card>
+                                                <CardHeader>
+                                                        <CardTitle className="flex items-center gap-2">
+                                                                <BarChart3 className="h-5 w-5 text-sky-500" />
+                                                                Status distribution
+                                                        </CardTitle>
+                                                </CardHeader>
+                                                <CardContent className="space-y-4">
+                                                        {(analytics.statusDistribution || []).map((item) => (
+                                                                <div
+                                                                        key={item.status}
+                                                                        className="space-y-1 rounded-lg border border-gray-100 p-3"
+                                                                >
+                                                                        <div className="flex items-center justify-between text-sm font-medium">
+                                                                                <span className="capitalize">
+                                                                                        {item.status}
+                                                                                </span>
+                                                                                <span>{item.count.toLocaleString()}</span>
+                                                                        </div>
+                                                                        <Progress
+                                                                                value={
+                                                                                        (item.count / statusMax) * 100
+                                                                                }
+                                                                        />
+                                                                        <p className="text-xs text-muted-foreground">
+                                                                                {formatCurrency(item.revenue)} revenue
+                                                                        </p>
+                                                                </div>
+                                                        ))}
+                                                </CardContent>
+                                        </Card>
+
+                                        <Card>
+                                                <CardHeader>
+                                                        <CardTitle className="flex items-center gap-2">
+                                                                <ShoppingBag className="h-5 w-5 text-emerald-500" />
+                                                                Payment mix
+                                                        </CardTitle>
+                                                </CardHeader>
+                                                <CardContent className="space-y-4">
+                                                        {(analytics.paymentMethods || []).map((item) => (
+                                                                <div key={item.method} className="flex items-center justify-between">
+                                                                        <div>
+                                                                                <p className="font-medium capitalize">
+                                                                                        {item.method}
+                                                                                </p>
+                                                                                <p className="text-xs text-muted-foreground">
+                                                                                        {item.count.toLocaleString()} orders
+                                                                                </p>
+                                                                        </div>
+                                                                        <span className="text-sm font-semibold">
+                                                                                {formatCurrency(item.revenue)}
+                                                                        </span>
+                                                                </div>
+                                                        ))}
+                                                </CardContent>
+                                        </Card>
+                                </div>
+                        </div>
+
+                        <Card>
+                                <CardHeader>
+                                        <CardTitle className="flex items-center gap-2">
+                                                <Users className="h-5 w-5 text-purple-500" />
+                                                Seller performance snapshot
+                                        </CardTitle>
+                                </CardHeader>
+                                <CardContent className="overflow-x-auto">
+                                        <Table>
+                                                <TableHeader>
+                                                        <TableRow>
+                                                                <TableHead>Seller</TableHead>
+                                                                <TableHead>Revenue</TableHead>
+                                                                <TableHead>Orders</TableHead>
+                                                                <TableHead>Units</TableHead>
+                                                                <TableHead>AOV</TableHead>
+                                                                <TableHead>Status mix</TableHead>
+                                                        </TableRow>
+                                                </TableHeader>
+                                                <TableBody>
+                                                        {(analytics.sellerPerformance || []).map((seller) => (
+                                                                <TableRow key={seller.sellerId}>
+                                                                        <TableCell>
+                                                                                <div className="flex flex-col">
+                                                                                        <span className="font-medium">
+                                                                                                {seller.displayName}
+                                                                                        </span>
+                                                                                        <span className="text-xs text-muted-foreground">
+                                                                                                {seller.email || seller.phone}
+                                                                                        </span>
+                                                                                        <span className="text-xs text-muted-foreground">
+                                                                                                {seller.brandName || seller.companyName}
+                                                                                        </span>
+                                                                                </div>
+                                                                        </TableCell>
+                                                                        <TableCell>{formatCurrency(seller.totalRevenue)}</TableCell>
+                                                                        <TableCell>{seller.totalOrders.toLocaleString()}</TableCell>
+                                                                        <TableCell>{seller.totalUnits.toLocaleString()}</TableCell>
+                                                                        <TableCell>
+                                                                                {formatCurrency(seller.averageOrderValue)}
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                                <div className="flex flex-wrap gap-1">
+                                                                                        {(seller.statusBreakdown || []).map(
+                                                                                                (status) => (
+                                                                                                        <Badge
+                                                                                                                key={`${seller.sellerId}-${status.status}`}
+                                                                                                                variant="outline"
+                                                                                                        >
+                                                                                                                {status.status} · {status.orders}
+                                                                                                        </Badge>
+                                                                                                )
+                                                                                        )}
+                                                                                </div>
+                                                                        </TableCell>
+                                                                </TableRow>
+                                                        ))}
+                                                </TableBody>
+                                        </Table>
+                                        {!(analytics.sellerPerformance || []).length && (
+                                                <p className="py-6 text-center text-sm text-muted-foreground">
+                                                        No seller activity in the selected period.
+                                                </p>
+                                        )}
+                                </CardContent>
+                        </Card>
+
+                        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle className="flex items-center gap-2">
+                                                        <BarChart3 className="h-5 w-5 text-indigo-500" />
+                                                        Category performance
+                                                </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="overflow-x-auto">
+                                                <Table>
+                                                        <TableHeader>
+                                                                <TableRow>
+                                                                        <TableHead>Category</TableHead>
+                                                                        <TableHead>Revenue</TableHead>
+                                                                        <TableHead>Units</TableHead>
+                                                                        <TableHead>Orders</TableHead>
+                                                                </TableRow>
+                                                        </TableHeader>
+                                                        <TableBody>
+                                                                {(analytics.categoryPerformance || []).map(
+                                                                        (category) => (
+                                                                                <TableRow key={category.category}>
+                                                                                        <TableCell className="font-medium">
+                                                                                                {category.category}
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                {formatCurrency(category.totalRevenue)}
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                {category.totalUnits.toLocaleString()}
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                {category.orderCount.toLocaleString()}
+                                                                                        </TableCell>
+                                                                                </TableRow>
+                                                                        )
+                                                                )}
+                                                        </TableBody>
+                                                </Table>
+                                                {!(analytics.categoryPerformance || []).length && (
+                                                        <p className="py-6 text-center text-sm text-muted-foreground">
+                                                                No category insights for this period.
+                                                        </p>
+                                                )}
+                                        </CardContent>
+                                </Card>
+
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle className="flex items-center gap-2">
+                                                        <LineChart className="h-5 w-5 text-rose-500" />
+                                                        Customer insights
+                                                </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="space-y-4">
+                                                <div className="grid grid-cols-2 gap-4">
+                                                        <div>
+                                                                <p className="text-sm text-muted-foreground">
+                                                                        Total customers
+                                                                </p>
+                                                                <p className="text-2xl font-semibold">
+                                                                        {analytics.customerSegments.totalCustomers.toLocaleString()}
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <p className="text-sm text-muted-foreground">
+                                                                        Returning
+                                                                </p>
+                                                                <p className="text-2xl font-semibold">
+                                                                        {analytics.customerSegments.returningCustomers.toLocaleString()}
+                                                                </p>
+                                                        </div>
+                                                </div>
+                                                <div className="space-y-3">
+                                                        <div>
+                                                                <div className="flex items-center justify-between text-sm">
+                                                                        <span>Repeat customers</span>
+                                                                        <span>
+                                                                                {analytics.customerSegments.repeatCustomers.toLocaleString()}
+                                                                        </span>
+                                                                </div>
+                                                                <Progress
+                                                                        value={
+                                                                                (analytics.customerSegments.repeatCustomers /
+                                                                                        totalCustomers) *
+                                                                                100
+                                                                        }
+                                                                />
+                                                        </div>
+                                                        <div>
+                                                                <div className="flex items-center justify-between text-sm">
+                                                                        <span>New this period</span>
+                                                                        <span>
+                                                                                {analytics.customerSegments.newCustomers.toLocaleString()}
+                                                                        </span>
+                                                                </div>
+                                                                <Progress
+                                                                        value={
+                                                                                (analytics.customerSegments.newCustomers /
+                                                                                        totalCustomers) *
+                                                                                100
+                                                                        }
+                                                                        className="bg-emerald-100"
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="rounded-lg border border-gray-100 p-3 text-sm">
+                                                        <div className="flex items-center justify-between">
+                                                                <span>Avg. order frequency</span>
+                                                                <span className="font-medium">
+                                                                        {analytics.customerSegments.avgOrderFrequency?.toFixed?.(
+                                                                                1
+                                                                        ) || 0}
+                                                                        ×
+                                                                </span>
+                                                        </div>
+                                                        <div className="flex items-center justify-between">
+                                                                <span>Customer lifetime value</span>
+                                                                <span className="font-medium">
+                                                                        {formatCurrency(
+                                                                                analytics.customerSegments.customerLifetimeValue
+                                                                        )}
+                                                                </span>
+                                                        </div>
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle className="flex items-center gap-2">
+                                                        <ShoppingBag className="h-5 w-5 text-amber-500" />
+                                                        Top products
+                                                </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="space-y-4">
+                                                {(analytics.topProducts || []).map((product) => (
+                                                        <div
+                                                                key={product.productId || product.productName}
+                                                                className="flex items-center justify-between rounded-lg border border-gray-100 p-3"
+                                                        >
+                                                                <div>
+                                                                        <p className="font-medium">
+                                                                                {product.productName}
+                                                                        </p>
+                                                                        <p className="text-xs text-muted-foreground">
+                                                                                {product.totalUnits.toLocaleString()} units
+                                                                        </p>
+                                                                </div>
+                                                                <span className="text-sm font-semibold">
+                                                                        {formatCurrency(product.totalRevenue)}
+                                                                </span>
+                                                        </div>
+                                                ))}
+                                                {!(analytics.topProducts || []).length && (
+                                                        <p className="py-4 text-center text-sm text-muted-foreground">
+                                                                No product sales in this range.
+                                                        </p>
+                                                )}
+                                        </CardContent>
+                                </Card>
+
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle className="flex items-center gap-2">
+                                                        <Users className="h-5 w-5 text-blue-500" />
+                                                        Top customers
+                                                </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="overflow-x-auto">
+                                                <Table>
+                                                        <TableHeader>
+                                                                <TableRow>
+                                                                        <TableHead>Customer</TableHead>
+                                                                        <TableHead>Orders</TableHead>
+                                                                        <TableHead>Units</TableHead>
+                                                                        <TableHead>Revenue</TableHead>
+                                                                </TableRow>
+                                                        </TableHeader>
+                                                        <TableBody>
+                                                                {(analytics.reports.customers || []).map((customer) => (
+                                                                        <TableRow key={customer.customerId}>
+                                                                                <TableCell>
+                                                                                        <div className="flex flex-col">
+                                                                                                <span className="font-medium">
+                                                                                                        {[
+                                                                                                                customer.firstName,
+                                                                                                                customer.lastName,
+                                                                                                        ]
+                                                                                                                .filter(Boolean)
+                                                                                                                .join(" ") ||
+                                                                                                        customer.email ||
+                                                                                                        customer.phone ||
+                                                                                                        customer.customerId}
+                                                                                                </span>
+                                                                                                <span className="text-xs text-muted-foreground">
+                                                                                                        {customer.email || customer.phone || ""}
+                                                                                                </span>
+                                                                                        </div>
+                                                                                </TableCell>
+                                                                                <TableCell>{customer.orders}</TableCell>
+                                                                                <TableCell>{customer.units}</TableCell>
+                                                                                <TableCell>
+                                                                                        {formatCurrency(customer.totalRevenue)}
+                                                                                </TableCell>
+                                                                        </TableRow>
+                                                                ))}
+                                                        </TableBody>
+                                                </Table>
+                                                {!(analytics.reports.customers || []).length && (
+                                                        <p className="py-4 text-center text-sm text-muted-foreground">
+                                                                No customer activity in this range.
+                                                        </p>
+                                                )}
+                                        </CardContent>
+                                </Card>
+                        </div>
+
+                        <Card>
+                                <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                                        <CardTitle className="flex items-center gap-2">
+                                                <ListFilter className="h-5 w-5 text-slate-600" />
+                                                Orders report
+                                        </CardTitle>
+                                        <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={handleExportOrders}
+                                                disabled={loading}
+                                        >
+                                                <Download className="mr-2 h-4 w-4" />
+                                                Download CSV
+                                        </Button>
+                                </CardHeader>
+                                <CardContent className="overflow-x-auto">
+                                        <Table>
+                                                <TableHeader>
+                                                        <TableRow>
+                                                                <TableHead>Order</TableHead>
+                                                                <TableHead>Date</TableHead>
+                                                                <TableHead>Status</TableHead>
+                                                                <TableHead>Payment</TableHead>
+                                                                <TableHead>Units</TableHead>
+                                                                <TableHead>Total</TableHead>
+                                                        </TableRow>
+                                                </TableHeader>
+                                                <TableBody>
+                                                        {(analytics.reports.orders || []).map((order) => (
+                                                                <TableRow key={order.id}>
+                                                                        <TableCell className="font-medium">
+                                                                                {order.orderNumber}
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                                {order.orderDate
+                                                                                        ? new Date(order.orderDate).toLocaleString()
+                                                                                        : "-"}
+                                                                        </TableCell>
+                                                                        <TableCell className="capitalize">
+                                                                                {order.status}
+                                                                        </TableCell>
+                                                                        <TableCell className="capitalize">
+                                                                                {order.paymentMethod}
+                                                                        </TableCell>
+                                                                        <TableCell>{order.units}</TableCell>
+                                                                        <TableCell>
+                                                                                {formatCurrency(order.totalAmount)}
+                                                                        </TableCell>
+                                                                </TableRow>
+                                                        ))}
+                                                </TableBody>
+                                        </Table>
+                                        {!(analytics.reports.orders || []).length && (
+                                                <p className="py-6 text-center text-sm text-muted-foreground">
+                                                        No orders found for the selected filters.
+                                                </p>
+                                        )}
+                                </CardContent>
+                        </Card>
+
+                        {loading && (
+                                <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/60 backdrop-blur-sm">
+                                        <div className="flex items-center gap-3 rounded-lg border border-gray-100 bg-white px-4 py-3 shadow-lg">
+                                                <RefreshCw className="h-4 w-4 animate-spin text-orange-600" />
+                                                <span className="text-sm font-medium text-gray-600">
+                                                        Updating insights...
+                                                </span>
+                                        </div>
+                                </div>
+                        )}
+                </div>
+        );
+}

--- a/store/adminAnalyticsStore.js
+++ b/store/adminAnalyticsStore.js
@@ -1,0 +1,276 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+const formatDateInput = (date) => date.toISOString().split("T")[0];
+
+const today = new Date();
+const defaultEnd = formatDateInput(today);
+const start = new Date(today);
+start.setDate(start.getDate() - 29);
+const defaultStart = formatDateInput(start);
+
+const buildInitialFilters = () => ({
+        startDate: defaultStart,
+        endDate: defaultEnd,
+        interval: "day",
+        statuses: [],
+        paymentMethods: [],
+        categories: [],
+        sellers: [],
+});
+
+const initialFilters = buildInitialFilters();
+
+const buildInitialAnalytics = () => ({
+        summary: {
+                totalOrders: 0,
+                totalRevenue: 0,
+                totalUnits: 0,
+                averageOrderValue: 0,
+                uniqueCustomers: 0,
+        },
+        ordersOverTime: [],
+        statusDistribution: [],
+        paymentMethods: [],
+        topProducts: [],
+        categoryPerformance: [],
+        sellerPerformance: [],
+        customerSegments: {
+                totalCustomers: 0,
+                repeatCustomers: 0,
+                newCustomers: 0,
+                returningCustomers: 0,
+                avgOrderFrequency: 0,
+                customerLifetimeValue: 0,
+        },
+        reports: {
+                orders: [],
+                sellers: [],
+                customers: [],
+        },
+        growth: {
+                revenue: 0,
+                orders: 0,
+                units: 0,
+        },
+        availableFilters: {
+                statuses: [],
+                paymentMethods: [],
+                categories: [],
+                sellers: [],
+        },
+        meta: {
+                startDate: null,
+                endDate: null,
+                interval: "day",
+        },
+});
+
+const initialAnalytics = buildInitialAnalytics();
+
+export const useAdminAnalyticsStore = create(
+        devtools((set, get) => ({
+                filters: initialFilters,
+                analytics: initialAnalytics,
+                loading: false,
+                error: null,
+                setFilter: (key, value) =>
+                        set((state) => ({
+                                filters: {
+                                        ...state.filters,
+                                        [key]: value,
+                                },
+                        })),
+                setFilters: (filters) =>
+                        set(() => ({
+                                filters: {
+                                        ...buildInitialFilters(),
+                                        ...filters,
+                                },
+                        })),
+                resetFilters: () =>
+                        set(() => ({
+                                filters: buildInitialFilters(),
+                        })),
+                fetchAnalytics: async () => {
+                        const { filters } = get();
+                        const params = new URLSearchParams();
+
+                        if (filters.startDate) params.set("startDate", filters.startDate);
+                        if (filters.endDate) params.set("endDate", filters.endDate);
+                        if (filters.interval) params.set("interval", filters.interval);
+                        if (filters.statuses.length) {
+                                params.set("status", filters.statuses.join(","));
+                        }
+                        if (filters.paymentMethods.length) {
+                                params.set(
+                                        "paymentMethods",
+                                        filters.paymentMethods.join(",")
+                                );
+                        }
+                        if (filters.categories.length) {
+                                params.set("categories", filters.categories.join(","));
+                        }
+                        if (filters.sellers.length) {
+                                params.set("sellers", filters.sellers.join(","));
+                        }
+
+                        set({ loading: true, error: null });
+
+                        try {
+                                const response = await fetch(
+                                        `/api/admin/analytics?${params.toString()}`,
+                                        {
+                                                method: "GET",
+                                                credentials: "include",
+                                        }
+                                );
+
+                                const payload = await response.json();
+
+                                if (!response.ok || !payload.success) {
+                                        throw new Error(
+                                                payload.message ||
+                                                        "Failed to load analytics"
+                                        );
+                                }
+
+                                set({
+                                        analytics: {
+                                                ...payload.data,
+                                                availableFilters:
+                                                        payload.data.availableFilters,
+                                        },
+                                        loading: false,
+                                });
+                        } catch (error) {
+                                console.error("Admin analytics store error:", error);
+                                set({
+                                        loading: false,
+                                        error:
+                                                error.message ||
+                                                "Unable to load analytics",
+                                        analytics: buildInitialAnalytics(),
+                                });
+                        }
+                },
+                exportOrdersReport: () => {
+                        const {
+                                analytics: {
+                                        reports: { orders },
+                                },
+                        } = get();
+
+                        if (!orders?.length) {
+                                return null;
+                        }
+
+                        const header = [
+                                "Order Number",
+                                "Order Date",
+                                "Status",
+                                "Payment Method",
+                                "Units",
+                                "Total Amount",
+                                "Categories",
+                        ];
+
+                        const rows = orders.map((order) => [
+                                order.orderNumber,
+                                order.orderDate
+                                        ? new Date(order.orderDate).toISOString()
+                                        : "",
+                                order.status,
+                                order.paymentMethod,
+                                order.units,
+                                order.totalAmount,
+                                order.categories?.join(" | ") || "",
+                        ]);
+
+                        const csvContent = [header, ...rows]
+                                .map((row) =>
+                                        row
+                                                .map((value) => {
+                                                        if (value === null || value === undefined)
+                                                                return "";
+                                                        const stringValue = String(value);
+                                                        if (stringValue.includes(",")) {
+                                                                return `"${stringValue.replace(/"/g, '""')}"`;
+                                                        }
+                                                        return stringValue;
+                                                })
+                                                .join(",")
+                                )
+                                .join("\n");
+
+                        return new Blob([csvContent], {
+                                type: "text/csv;charset=utf-8;",
+                        });
+                },
+                exportSellerReport: () => {
+                        const {
+                                analytics: { sellerPerformance },
+                        } = get();
+
+                        if (!sellerPerformance?.length) {
+                                return null;
+                        }
+
+                        const header = [
+                                "Seller",
+                                "Email",
+                                "Phone",
+                                "Company",
+                                "Brand",
+                                "Total Revenue",
+                                "Total Orders",
+                                "Units",
+                                "Average Order Value",
+                        ];
+
+                        const rows = sellerPerformance.map((seller) => [
+                                seller.displayName || seller.name || "",
+                                seller.email || "",
+                                seller.phone || "",
+                                seller.companyName || "",
+                                seller.brandName || "",
+                                seller.totalRevenue,
+                                seller.totalOrders,
+                                seller.totalUnits,
+                                seller.averageOrderValue,
+                        ]);
+
+                        const csvContent = [header, ...rows]
+                                .map((row) =>
+                                        row
+                                                .map((value) => {
+                                                        if (value === null || value === undefined)
+                                                                return "";
+                                                        const stringValue = String(value);
+                                                        if (stringValue.includes(",")) {
+                                                                return `"${stringValue.replace(/"/g, '""')}"`;
+                                                        }
+                                                        return stringValue;
+                                                })
+                                                .join(",")
+                                )
+                                .join("\n");
+
+                        return new Blob([csvContent], {
+                                type: "text/csv;charset=utf-8;",
+                        });
+                },
+        }))
+);
+
+export const useAdminAnalyticsFilters = () =>
+        useAdminAnalyticsStore((state) => state.filters);
+
+export const useAdminAnalyticsData = () =>
+        useAdminAnalyticsStore((state) => state.analytics);
+
+export const useAdminAnalyticsLoading = () =>
+        useAdminAnalyticsStore((state) => state.loading);
+
+export const useAdminAnalyticsError = () =>
+        useAdminAnalyticsStore((state) => state.error);


### PR DESCRIPTION
## Summary
- add a comprehensive `/api/admin/analytics` endpoint that authenticates admins, applies rich filters, and returns marketplace, seller, and customer performance data
- introduce an admin analytics store, route, and UI that surface filters, charts, exports, and seller/customer reports in the admin panel
- expose the new analytics experience in the admin sidebar navigation
