### PR TITLE
Fix admin analytics page dynamic import for client compatibility

### DIFF
--- a/app/admin/analytics/AdminAnalyticsClient.jsx
+++ b/app/admin/analytics/AdminAnalyticsClient.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const AdminAnalytics = dynamic(
+        () => import("@/components/AdminPanel/Analytics/AdminAnalytics.jsx"),
+        { ssr: false }
+);
+
+export default function AdminAnalyticsClient() {
+        return <AdminAnalytics />;
+}

--- a/app/admin/analytics/page.jsx
+++ b/app/admin/analytics/page.jsx
@@ -1,10 +1,5 @@
-import dynamic from "next/dynamic";
-
-const AdminAnalytics = dynamic(
-        () => import("@/components/AdminPanel/Analytics/AdminAnalytics.jsx"),
-        { ssr: false }
-);
+import AdminAnalyticsClient from "./AdminAnalyticsClient";
 
 export default function AdminAnalyticsPage() {
-        return <AdminAnalytics />;
+        return <AdminAnalyticsClient />;
 }


### PR DESCRIPTION
## Summary
- move the dynamic AdminAnalytics import into a client component to allow `ssr: false`
- update the admin analytics page to render the new client wrapper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da84efb470832e9e7e6b99168fddc2