### PR TITLE
Add navigation order management to admin categories

### DIFF
--- a/app/admin/catalog/categories/page.jsx
+++ b/app/admin/catalog/categories/page.jsx
@@ -47,27 +47,45 @@ export default function AdminCategoriesPage() {
 	const isAuthenticated = useIsAuthenticated();
 	const [isRedirecting, setIsRedirecting] = useState(false);
 	const router = useRouter();
-	const {
-		categories,
-		isLoading,
-		error,
-		filters,
-		pagination,
-		selectedCategories,
-		fetchCategories,
-		setFilters,
-		resetFilters,
-		setPage,
-		setSorting,
-		selectAllCategories,
-		clearSelection,
-		toggleCategorySelection,
-		deleteCategory,
-		deleteMultipleCategories,
-		updateCategory,
-		exportToCSV,
-		exportToJSON,
-	} = useAdminCategoryStore();
+        const {
+                categories,
+                isLoading,
+                error,
+                filters,
+                pagination,
+                selectedCategories,
+                fetchCategories,
+                setFilters,
+                resetFilters,
+                setPage,
+                setSorting,
+                selectAllCategories,
+                clearSelection,
+                toggleCategorySelection,
+                deleteCategory,
+                deleteMultipleCategories,
+                updateCategory,
+                exportToCSV,
+                exportToJSON,
+                sortBy,
+                sortOrder,
+        } = useAdminCategoryStore();
+
+        const [navOrderDrafts, setNavOrderDrafts] = useState({});
+        const [navOrderSaving, setNavOrderSaving] = useState({});
+
+        useEffect(() => {
+                const initialDrafts = categories.reduce((acc, category) => {
+                        acc[category._id] =
+                                category.navigationOrder === undefined ||
+                                category.navigationOrder === null
+                                        ? ""
+                                        : String(category.navigationOrder);
+                        return acc;
+                }, {});
+
+                setNavOrderDrafts(initialDrafts);
+        }, [categories]);
 
 	const [popups, setPopups] = useState({
 		delete: { open: false, category: null },
@@ -141,10 +159,59 @@ export default function AdminCategoriesPage() {
 		await updateCategory(categoryId, { published });
 	};
 
-	const handleSort = (field) => {
-		const currentOrder = filters.sortOrder === "desc" ? "asc" : "desc";
-		setSorting(field, currentOrder);
-	};
+        const handleSort = (field) => {
+                const currentOrder =
+                        sortBy === field && sortOrder === "asc" ? "desc" : "asc";
+                setSorting(field, currentOrder);
+        };
+
+        const handleNavOrderChange = (categoryId, value) => {
+                setNavOrderDrafts((prev) => ({
+                        ...prev,
+                        [categoryId]: value,
+                }));
+        };
+
+        const commitNavOrderChange = async (categoryId) => {
+                if (navOrderSaving[categoryId]) {
+                        return;
+                }
+
+                const draftValue = navOrderDrafts[categoryId];
+                const parsedValue = Number(draftValue);
+
+                const normalizedValue =
+                        draftValue === "" || !Number.isFinite(parsedValue) || parsedValue < 0
+                                ? 0
+                                : parsedValue;
+
+                const category = categories.find((cat) => cat._id === categoryId);
+                if (!category) return;
+
+                if ((category.navigationOrder || 0) === normalizedValue) {
+                        // Ensure empty drafts reflect normalized value
+                        setNavOrderDrafts((prev) => ({
+                                ...prev,
+                                [categoryId]: String(normalizedValue),
+                        }));
+                        return;
+                }
+
+                setNavOrderSaving((prev) => ({ ...prev, [categoryId]: true }));
+                try {
+                        const success = await updateCategory(categoryId, {
+                                navigationOrder: normalizedValue,
+                        });
+                        if (!success) {
+                                setNavOrderDrafts((prev) => ({
+                                        ...prev,
+                                        [categoryId]: String(category.navigationOrder || 0),
+                                }));
+                        }
+                } finally {
+                        setNavOrderSaving((prev) => ({ ...prev, [categoryId]: false }));
+                }
+        };
 
 	if (error) {
 		return (
@@ -296,8 +363,22 @@ export default function AdminCategoriesPage() {
 												</Button>
 											</TableHead>
 											<TableHead>Subcategories</TableHead>
-											<TableHead>Products</TableHead>
-											<TableHead>Published</TableHead>
+                                                                                        <TableHead>Products</TableHead>
+                                                                                        <TableHead>
+                                                                                                <Button
+                                                                                                        variant="ghost"
+                                                                                                        onClick={() =>
+                                                                                                                handleSort(
+                                                                                                                        "navigationOrder"
+                                                                                                                )
+                                                                                                        }
+                                                                                                        className="p-0 h-auto font-medium"
+                                                                                                >
+                                                                                                        Nav Order
+                                                                                                        <ArrowUpDown className="ml-2 h-4 w-4" />
+                                                                                                </Button>
+                                                                                        </TableHead>
+                                                                                        <TableHead>Published</TableHead>
 											<TableHead>
 												<Button
 													variant="ghost"
@@ -363,14 +444,45 @@ export default function AdminCategoriesPage() {
 														{category.productCount || 0} products
 													</Badge>
 												</TableCell>
-												<TableCell>
-													<Switch
-														checked={!!category.published}
-														onCheckedChange={(checked) =>
-															handlePublishToggle(category._id, checked)
-														}
-													/>
-												</TableCell>
+                                                                                                <TableCell>
+                                                                                                        <div className="max-w-[6rem]">
+                                                                                                                <Input
+                                                                                                                        type="number"
+                                                                                                                        min={0}
+                                                                                                                        value={
+                                                                                                                                navOrderDrafts[category._id] ?? ""
+                                                                                                                        }
+                                                                                                                        onChange={(e) =>
+                                                                                                                                handleNavOrderChange(
+                                                                                                                                        category._id,
+                                                                                                                                        e.target.value
+                                                                                                                                )
+                                                                                                                        }
+                                                                                                                        onBlur={() =>
+                                                                                                                                commitNavOrderChange(
+                                                                                                                                        category._id
+                                                                                                                                )
+                                                                                                                        }
+                                                                                                                        onKeyDown={(e) => {
+                                                                                                                                if (e.key === "Enter") {
+                                                                                                                                        commitNavOrderChange(
+                                                                                                                                                category._id
+                                                                                                                                        );
+                                                                                                                                }
+                                                                                                                        }}
+                                                                                                                        disabled={!!navOrderSaving[category._id]}
+                                                                                                                        className="h-9"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <Switch
+                                                                                                                checked={!!category.published}
+                                                                                                                onCheckedChange={(checked) =>
+                                                                                                                        handlePublishToggle(category._id, checked)
+                                                                                                                }
+                                                                                                        />
+                                                                                                </TableCell>
 												<TableCell>
 													<div className="text-sm text-gray-500">
 														{category.createdAt

--- a/app/api/categories/route.js
+++ b/app/api/categories/route.js
@@ -9,7 +9,7 @@ export async function GET() {
 
 		// Only published categories
                 const cats = await Category.find({ published: true })
-                        .sort({ name: 1 })
+                        .sort({ navigationOrder: 1, name: 1 })
                         .lean();
 
                 const categoriesWithCounts = await attachProductCountsToCategories(
@@ -43,6 +43,7 @@ export async function GET() {
                                 _id: category._id,
                                 name: category.name,
                                 slug: categorySlug,
+                                navigationOrder: Number(category.navigationOrder) || 0,
                                 productCount:
                                         directProductCount > 0
                                                 ? directProductCount

--- a/app/api/products/filters/route.js
+++ b/app/api/products/filters/route.js
@@ -107,10 +107,27 @@ export async function GET() {
 		});
 
 		// Execute all category updates
-		const updatedCategories = await Promise.all(categoryUpdatePromises);
+                const updatedCategories = await Promise.all(categoryUpdatePromises);
 
-		// Format categories for response
-                const formattedCategories = updatedCategories.map((cat) => {
+                const sortedCategories = updatedCategories
+                        .filter(Boolean)
+                        .sort((a, b) => {
+                                const aOrder = Number.isFinite(Number(a?.navigationOrder))
+                                        ? Number(a.navigationOrder)
+                                        : Number.MAX_SAFE_INTEGER;
+                                const bOrder = Number.isFinite(Number(b?.navigationOrder))
+                                        ? Number(b.navigationOrder)
+                                        : Number.MAX_SAFE_INTEGER;
+
+                                if (aOrder === bOrder) {
+                                        return (a?.name || "").localeCompare(b?.name || "");
+                                }
+
+                                return aOrder - bOrder;
+                        });
+
+                // Format categories for response
+                const formattedCategories = sortedCategories.map((cat) => {
                         const categorySlug = slugify(cat.slug || cat.name);
 
                         return {

--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -219,8 +219,10 @@ export async function GET(request) {
                         if (!categoriesCache) {
                                 categoriesCache = await Categories.find(
                                         { published: true },
-                                        { name: 1, subCategories: 1 }
-                                ).lean();
+                                        { name: 1, subCategories: 1, navigationOrder: 1 }
+                                )
+                                        .sort({ navigationOrder: 1, name: 1 })
+                                        .lean();
                         }
 
                         return categoriesCache;

--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -22,6 +22,7 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 
         const [formData, setFormData] = useState({
                 name: "",
+                navigationOrder: "",
                 published: true,
                 subCategories: [],
         });
@@ -61,8 +62,14 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                 setIsSubmitting(true);
 
 		// sanitize
+                const navOrderNumber = Number(formData.navigationOrder);
+
                 const payload = {
                         name: formData.name.trim(),
+                        navigationOrder:
+                                Number.isFinite(navOrderNumber) && navOrderNumber >= 0
+                                        ? navOrderNumber
+                                        : 0,
                         published: formData.published,
                         subCategories: (formData.subCategories || [])
                                 .filter((s) => (s.name || "").trim() !== "")
@@ -86,6 +93,7 @@ export function AddCategoryPopup({ open, onOpenChange }) {
         const resetForm = () => {
                 setFormData({
                         name: "",
+                        navigationOrder: "",
                         published: true,
                         subCategories: [],
                 });
@@ -109,9 +117,9 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 					</DialogHeader>
 
 					<form onSubmit={handleSubmit} className="space-y-4 mt-4">
-						<div>
-							<Label htmlFor="name">Category Name *</Label>
-							<Input
+                                                <div>
+                                                        <Label htmlFor="name">Category Name *</Label>
+                                                        <Input
 								id="name"
 								placeholder="Enter category name"
 								value={formData.name}
@@ -120,8 +128,32 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 								}
 								className="mt-1"
 								required
-							/>
-						</div>
+                                                        />
+                                                </div>
+
+                                                <div>
+                                                        <Label htmlFor="navigationOrder">
+                                                                Navigation Order
+                                                        </Label>
+                                                        <Input
+                                                                id="navigationOrder"
+                                                                type="number"
+                                                                min={0}
+                                                                placeholder="e.g. 1"
+                                                                value={formData.navigationOrder}
+                                                                onChange={(e) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                navigationOrder:
+                                                                                        e.target.value,
+                                                                        })
+                                                                }
+                                                                className="mt-1"
+                                                        />
+                                                        <p className="text-sm text-gray-500 mt-1">
+                                                                Controls the left-to-right order in the navigation bar.
+                                                        </p>
+                                                </div>
 
 						<div className="flex items-center justify-between">
 							<div>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -28,24 +28,31 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 	const { updateCategory } = useAdminCategoryStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		name: "",
-		published: true,
-		subCategories: [],
-	});
+        const [formData, setFormData] = useState({
+                name: "",
+                navigationOrder: "",
+                published: true,
+                subCategories: [],
+        });
 
 	useEffect(() => {
 		if (category) {
-			setFormData({
-				name: category.name || "",
-				published: category.published !== undefined ? category.published : true,
-				subCategories: Array.isArray(category.subCategories)
-					? category.subCategories.map((s) => ({
-							name: s.name || "",
-							published: s.published !== undefined ? !!s.published : true,
-					  }))
-					: [],
-			});
+                        setFormData({
+                                name: category.name || "",
+                                navigationOrder:
+                                        category.navigationOrder !== undefined &&
+                                        category.navigationOrder !== null
+                                                ? String(category.navigationOrder)
+                                                : "",
+                                published:
+                                        category.published !== undefined ? category.published : true,
+                                subCategories: Array.isArray(category.subCategories)
+                                        ? category.subCategories.map((s) => ({
+                                                        name: s.name || "",
+                                                        published: s.published !== undefined ? !!s.published : true,
+                                          }))
+                                        : [],
+                        });
 		}
 	}, [category]);
 
@@ -86,11 +93,17 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 
 		setIsSubmitting(true);
 
-		const payload = {
-			name: formData.name.trim(),
-			published: formData.published,
-			subCategories: (formData.subCategories || []).filter(
-				(s) => (s.name || "").trim() !== ""
+                const navOrderNumber = Number(formData.navigationOrder);
+
+                const payload = {
+                        name: formData.name.trim(),
+                        navigationOrder:
+                                Number.isFinite(navOrderNumber) && navOrderNumber >= 0
+                                        ? navOrderNumber
+                                        : 0,
+                        published: formData.published,
+                        subCategories: (formData.subCategories || []).filter(
+                                (s) => (s.name || "").trim() !== ""
 			),
 		};
 
@@ -149,6 +162,30 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                         links.
                                                                 </p>
                                                         </div>
+                                                </div>
+
+                                                <div>
+                                                        <Label htmlFor="update-navigationOrder">
+                                                                Navigation Order
+                                                        </Label>
+                                                        <Input
+                                                                id="update-navigationOrder"
+                                                                type="number"
+                                                                min={0}
+                                                                placeholder="e.g. 1"
+                                                                value={formData.navigationOrder}
+                                                                onChange={(e) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                navigationOrder:
+                                                                                        e.target.value,
+                                                                        })
+                                                                }
+                                                                className="mt-1"
+                                                        />
+                                                        <p className="text-sm text-gray-500 mt-1">
+                                                                Determines the category position in navigation menus.
+                                                        </p>
                                                 </div>
 
 						<div className="flex items-center justify-between">

--- a/model/Categories.js
+++ b/model/Categories.js
@@ -16,7 +16,7 @@ const SubCategorySchema = new mongoose.Schema(
                         default: 0,
                 },
         },
-	{ _id: false }
+        { _id: false }
 );
 
 const CategorySchema = new mongoose.Schema(
@@ -33,11 +33,16 @@ const CategorySchema = new mongoose.Schema(
 			default: true,
 		},
 		// Number of products in this category and its subcategories
-		productCount: {
-			type: Number,
-			default: 0,
-		},
-	},
+                productCount: {
+                        type: Number,
+                        default: 0,
+                },
+                navigationOrder: {
+                        type: Number,
+                        default: 0,
+                        min: 0,
+                },
+        },
 	{
 		timestamps: true,
 	}

--- a/store/adminCategoryStore.js
+++ b/store/adminCategoryStore.js
@@ -19,8 +19,8 @@ export const useAdminCategoryStore = create((set, get) => ({
 		limit: 10,
 	},
 	selectedCategories: [],
-	sortBy: "createdAt",
-	sortOrder: "desc",
+        sortBy: "navigationOrder",
+        sortOrder: "asc",
 
 	// Actions
 	fetchCategories: async () => {
@@ -237,24 +237,26 @@ export const useAdminCategoryStore = create((set, get) => ({
 	exportToCSV: () => {
 		const { categories } = get();
 		const csvContent = [
-			[
-				"ID",
-				"Name",
-				"Subcategories",
-				"Published",
-				"Product Count",
-				"Created At",
-			].join(","),
-			...categories.map((category) =>
-				[
-					category._id,
-					`"${category.name}"`,
-					category.subCategories ? category.subCategories.length : 0,
-					category.published ? "Yes" : "No",
-					category.productCount || 0,
-					category.createdAt
-						? new Date(category.createdAt).toLocaleDateString()
-						: "",
+                        [
+                                "ID",
+                                "Name",
+                                "Subcategories",
+                                "Published",
+                                "Product Count",
+                                "Navigation Order",
+                                "Created At",
+                        ].join(","),
+                        ...categories.map((category) =>
+                                [
+                                        category._id,
+                                        `"${category.name}"`,
+                                        category.subCategories ? category.subCategories.length : 0,
+                                        category.published ? "Yes" : "No",
+                                        category.productCount || 0,
+                                        category.navigationOrder ?? 0,
+                                        category.createdAt
+                                                ? new Date(category.createdAt).toLocaleDateString()
+                                                : "",
 				].join(",")
 			),
 		].join("\n");


### PR DESCRIPTION
## Summary
- add UI controls to capture and edit category navigation order values within the admin list and popups
- persist the navigation order field through the API, data model, and exports while sorting public category endpoints accordingly
