### PR TITLE
Remove shipping charges from checkout

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -1035,15 +1035,12 @@ export default function CheckoutPage() {
                                                 )}
                                         </div>
 
-					{/* Free shipping message */}
-					{orderSummary.subtotal < 500 && (
-						<div className="p-3 bg-yellow-50 rounded-lg">
-							<p className="text-sm text-yellow-800">
-								Add ₹{(500 - orderSummary.subtotal).toLocaleString()} more for
-								free shipping!
-							</p>
-						</div>
-					)}
+                                        {/* Free shipping message */}
+                                        <div className="p-3 bg-green-50 rounded-lg">
+                                                <p className="text-sm text-green-800">
+                                                        Enjoy free shipping on every order—no minimum purchase required.
+                                                </p>
+                                        </div>
 				</CardContent>
 			</Card>
 		);

--- a/lib/orders/createOrder.js
+++ b/lib/orders/createOrder.js
@@ -10,7 +10,7 @@ function calculateTotals(items, { discountPercentage = 0, gstMode = "igst", gstR
         const subtotal = items.reduce((sum, item) => sum + (item.totalPrice || 0), 0);
         const discountAmount = (subtotal * discountPercentage) / 100;
         const discountedSubtotal = subtotal - discountAmount;
-        const shippingCost = discountedSubtotal >= 500 ? 0 : 50;
+        const shippingCost = 0;
 
         const totals = calculateGstTotals({
                 subtotal,

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -240,8 +240,8 @@ export const useCheckoutStore = create(
 						0
 					);
 
-					// Calculate shipping cost: free if subtotal >= 500, else 50
-					const shippingCost = subtotal >= 500 ? 0 : 50;
+                                        // Shipping is free for all orders
+                                        const shippingCost = 0;
 
 					// Set coupon based on checkout type
 					let discount = 0;
@@ -477,8 +477,8 @@ export const useCheckoutStore = create(
 						checkoutType,
 					} = get();
 
-					// Calculate shipping cost
-                                        const shippingCost = orderSummary.subtotal >= 500 ? 0 : 50;
+                                        // Shipping is free for all orders
+                                        const shippingCost = 0;
 
                                         // Calculate discount based on checkout type
                                         let discount = 0;
@@ -553,15 +553,16 @@ export const useCheckoutStore = create(
 						const couponToUse =
 							checkoutType === "cart" ? cartAppliedCoupon : appliedCoupon;
 
-						// Prepare order data
-                                        const shippingCost = orderSummary.subtotal >= 500 ? 0 : 50;
-                                        const totals = calculateGstTotals({
-                                                subtotal: orderSummary.subtotal,
-                                                discount: orderSummary.discount,
-                                                shippingCost,
-                                                address: selectedAddress,
-                                                gstMode: orderSummary.gst?.mode,
-                                        });
+                                                // Prepare order data
+                                                // Shipping is free for all orders
+                                                const shippingCost = 0;
+                                                const totals = calculateGstTotals({
+                                                        subtotal: orderSummary.subtotal,
+                                                        discount: orderSummary.discount,
+                                                        shippingCost,
+                                                        address: selectedAddress,
+                                                        gstMode: orderSummary.gst?.mode,
+                                                });
 
                                         set({
                                                 orderSummary: {


### PR DESCRIPTION
## Summary
- update checkout calculations to always treat shipping as free
- ensure backend order totals omit the previous ₹50 shipping charge
- refresh checkout messaging to highlight free shipping on all orders

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb59a2900832ea805a6b955cda5df