### PR TITLE
Add manual payout management for admin payments

### DIFF
--- a/app/api/admin/manual-payouts/route.js
+++ b/app/api/admin/manual-payouts/route.js
@@ -1,0 +1,498 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import jwt from "jsonwebtoken";
+
+import { dbConnect } from "@/lib/dbConnect.js";
+import Payment from "@/model/Payment.js";
+
+const ALLOWED_MANUAL_STATUSES = new Set(["pending", "scheduled", "paid"]);
+
+const toObjectId = (value) => {
+        if (!value) return null;
+        try {
+                return new mongoose.Types.ObjectId(value);
+        } catch (error) {
+                return null;
+        }
+};
+
+const escapeCsv = (value) => {
+        if (value === null || typeof value === "undefined") return "";
+        const stringValue = String(value ?? "");
+        if (stringValue.includes(",") || stringValue.includes("\"") || stringValue.includes("\n")) {
+                return `"${stringValue.replace(/"/g, '""')}"`;
+        }
+        return stringValue;
+};
+
+const buildAggregation = async ({ status, search, startDate, endDate }) => {
+        const matchStage = { payoutMode: "manual" };
+
+        const start = startDate ? new Date(startDate) : null;
+        const end = endDate ? new Date(endDate) : null;
+
+        if (start && !Number.isNaN(start.getTime()) && end && !Number.isNaN(end.getTime())) {
+                matchStage.createdAt = {
+                        $gte: start,
+                        $lte: end,
+                };
+        } else if (start && !Number.isNaN(start.getTime())) {
+                matchStage.createdAt = {
+                        $gte: start,
+                };
+        } else if (end && !Number.isNaN(end.getTime())) {
+                matchStage.createdAt = {
+                        $lte: end,
+                };
+        }
+
+        if (status && status !== "all" && ALLOWED_MANUAL_STATUSES.has(status)) {
+                matchStage.manualStatus = status;
+        }
+
+        if (search) {
+                matchStage.$or = [
+                        { "sellerSnapshot.name": { $regex: search, $options: "i" } },
+                        { "sellerSnapshot.email": { $regex: search, $options: "i" } },
+                        { "sellerSnapshot.businessName": { $regex: search, $options: "i" } },
+                ];
+        }
+
+        const aggregation = await Payment.aggregate([
+                { $match: matchStage },
+                {
+                        $group: {
+                                _id: "$sellerId",
+                                sellerSnapshot: { $first: "$sellerSnapshot" },
+                                totalOrders: { $sum: 1 },
+                                totalAmount: { $sum: "$sellerAmount" },
+                                pendingAmount: {
+                                        $sum: {
+                                                $cond: [{ $eq: ["$manualStatus", "pending"] }, "$sellerAmount", 0],
+                                        },
+                                },
+                                scheduledAmount: {
+                                        $sum: {
+                                                $cond: [{ $eq: ["$manualStatus", "scheduled"] }, "$sellerAmount", 0],
+                                        },
+                                },
+                                paidAmount: {
+                                        $sum: {
+                                                $cond: [{ $eq: ["$manualStatus", "paid"] }, "$sellerAmount", 0],
+                                        },
+                                },
+                                paymentIds: { $push: "$_id" },
+                                lastOrderDate: { $max: "$createdAt" },
+                                manualNotes: { $addToSet: "$manualNotes" },
+                                manualStatusSet: { $addToSet: "$manualStatus" },
+                        },
+                },
+                {
+                        $lookup: {
+                                from: "companies",
+                                let: { sellerId: "$_id" },
+                                pipeline: [
+                                        { $match: { $expr: { $eq: ["$user", "$$sellerId"] } } },
+                                        { $project: { bankDetails: 1 } },
+                                ],
+                                as: "company",
+                        },
+                },
+                {
+                        $addFields: {
+                                company: { $first: "$company" },
+                        },
+                },
+                {
+                        $addFields: {
+                                bankDetails: "$company.bankDetails",
+                                manualNotes: {
+                                        $first: {
+                                                $filter: {
+                                                        input: "$manualNotes",
+                                                        as: "note",
+                                                        cond: {
+                                                                $and: [
+                                                                        { $ne: ["$$note", null] },
+                                                                        { $ne: ["$$note", ""] },
+                                                                ],
+                                                        },
+                                                },
+                                        },
+                                },
+                                status: {
+                                        $cond: [
+                                                {
+                                                        $gt: [
+                                                                {
+                                                                        $size: {
+                                                                                $setIntersection: [
+                                                                                        "$manualStatusSet",
+                                                                                        ["pending"],
+                                                                                ],
+                                                                        },
+                                                                },
+                                                                0,
+                                                        ],
+                                                },
+                                                "pending",
+                                                {
+                                                        $cond: [
+                                                                {
+                                                                        $gt: [
+                                                                                {
+                                                                                        $size: {
+                                                                                                $setIntersection: [
+                                                                                                        "$manualStatusSet",
+                                                                                                        ["scheduled"],
+                                                                                                ],
+                                                                                        },
+                                                                                },
+                                                                                0,
+                                                                        ],
+                                                                },
+                                                                "scheduled",
+                                                                "paid",
+                                                        ],
+                                                },
+                                        ],
+                                },
+                        },
+                },
+                {
+                        $addFields: {
+                                sellerId: "$_id",
+                        },
+                },
+                {
+                        $project: {
+                                _id: 0,
+                                company: 0,
+                                manualStatusSet: 0,
+                        },
+                },
+                {
+                        $sort: {
+                                pendingAmount: -1,
+                                scheduledAmount: -1,
+                                totalAmount: -1,
+                        },
+                },
+        ]);
+
+        return aggregation.map((item) => ({
+                ...item,
+                bankDetails: item.bankDetails || null,
+                manualNotes: item.manualNotes || "",
+                status: item.status || "pending",
+        }));
+};
+
+export async function GET(request) {
+        try {
+                await dbConnect();
+
+                const token = request.cookies.get("admin_token")?.value;
+
+                if (!token) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                jwt.verify(token, process.env.JWT_SECRET);
+
+                const { searchParams } = new URL(request.url);
+                const page = Math.max(1, Number.parseInt(searchParams.get("page"), 10) || 1);
+                const limit = Math.min(
+                        100,
+                        Math.max(1, Number.parseInt(searchParams.get("limit"), 10) || 10)
+                );
+                const status = (searchParams.get("status") || "all").toLowerCase();
+                const search = searchParams.get("search")?.trim() || "";
+                const startDate = searchParams.get("startDate")?.trim() || "";
+                const endDate = searchParams.get("endDate")?.trim() || "";
+                const shouldExport = searchParams.get("export") === "csv";
+
+                const aggregation = await buildAggregation({ status, search, startDate, endDate });
+
+                const totalRecords = aggregation.length;
+                const totalPages = Math.max(1, Math.ceil(totalRecords / limit));
+                const startIndex = (page - 1) * limit;
+                const paginated = shouldExport
+                        ? aggregation
+                        : aggregation.slice(startIndex, startIndex + limit);
+
+                const stats = aggregation.reduce(
+                        (acc, seller) => {
+                                acc.totalSellers += 1;
+                                acc.pendingAmount += seller.pendingAmount || 0;
+                                acc.scheduledAmount += seller.scheduledAmount || 0;
+                                acc.paidAmount += seller.paidAmount || 0;
+                                return acc;
+                        },
+                        {
+                                totalSellers: 0,
+                                pendingAmount: 0,
+                                scheduledAmount: 0,
+                                paidAmount: 0,
+                        }
+                );
+
+                if (shouldExport) {
+                        const header = [
+                                "Seller Name",
+                                "Business Name",
+                                "Email",
+                                "Status",
+                                "Total Orders",
+                                "Pending Amount",
+                                "Scheduled Amount",
+                                "Paid Amount",
+                                "Bank Account Name",
+                                "Bank Account Number",
+                                "Bank Name",
+                                "IFSC",
+                                "UPI ID",
+                                "Last Order Date",
+                        ];
+
+                        const rows = aggregation.map((seller) => {
+                                const bank = seller.bankDetails || {};
+                                const lastOrderDate = seller.lastOrderDate
+                                        ? new Date(seller.lastOrderDate).toISOString()
+                                        : "";
+
+                                return [
+                                        escapeCsv(seller.sellerSnapshot?.name || ""),
+                                        escapeCsv(seller.sellerSnapshot?.businessName || ""),
+                                        escapeCsv(seller.sellerSnapshot?.email || ""),
+                                        escapeCsv(seller.status),
+                                        escapeCsv(seller.totalOrders),
+                                        escapeCsv(seller.pendingAmount.toFixed(2)),
+                                        escapeCsv(seller.scheduledAmount.toFixed(2)),
+                                        escapeCsv(seller.paidAmount.toFixed(2)),
+                                        escapeCsv(bank.accountHolderName || ""),
+                                        escapeCsv(bank.accountNumber || ""),
+                                        escapeCsv(bank.bankName || ""),
+                                        escapeCsv(bank.ifscCode || ""),
+                                        escapeCsv(bank.upiId || ""),
+                                        escapeCsv(lastOrderDate),
+                                ].join(",");
+                        });
+
+                        const csvContent = [header.join(","), ...rows].join("\n");
+
+                        return new NextResponse(csvContent, {
+                                status: 200,
+                                headers: {
+                                        "Content-Type": "text/csv",
+                                        "Content-Disposition": `attachment; filename="manual-payouts-${Date.now()}.csv"`,
+                                },
+                        });
+                }
+
+                return NextResponse.json({
+                        success: true,
+                        sellers: paginated,
+                        pagination: {
+                                currentPage: page,
+                                totalPages,
+                                totalRecords,
+                                hasNext: page < totalPages,
+                                hasPrev: page > 1,
+                        },
+                        stats,
+                });
+        } catch (error) {
+                console.error("Error fetching manual payouts:", error);
+                return NextResponse.json(
+                        {
+                                success: false,
+                                message: error.message || "Failed to fetch manual payouts",
+                        },
+                        { status: 500 }
+                );
+        }
+}
+
+export async function PATCH(request) {
+        try {
+                await dbConnect();
+
+                const token = request.cookies.get("admin_token")?.value;
+
+                if (!token) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                const admin = jwt.verify(token, process.env.JWT_SECRET);
+
+                const { updates } = await request.json();
+
+                if (!Array.isArray(updates) || updates.length === 0) {
+                        return NextResponse.json(
+                                { success: false, message: "No updates provided" },
+                                { status: 400 }
+                        );
+                }
+
+                let modifiedCount = 0;
+                const processedSellers = new Set();
+
+                for (const update of updates) {
+                        if (!update?.sellerId) continue;
+
+                        const sellerId = toObjectId(update.sellerId);
+
+                        if (!sellerId) continue;
+
+                        const query = {
+                                sellerId,
+                                payoutMode: "manual",
+                        };
+
+                        if (Array.isArray(update.paymentIds) && update.paymentIds.length > 0) {
+                                const paymentIds = update.paymentIds
+                                        .map((id) => toObjectId(id))
+                                        .filter(Boolean);
+
+                                if (paymentIds.length === 0) {
+                                        continue;
+                                }
+
+                                query._id = { $in: paymentIds };
+                        }
+
+                        const setDoc = {};
+                        const updateDoc = {};
+
+                        const status =
+                                typeof update.status === "string"
+                                        ? update.status.trim().toLowerCase()
+                                        : "";
+
+                        if (status) {
+                                if (!ALLOWED_MANUAL_STATUSES.has(status)) {
+                                        continue;
+                                }
+                                setDoc.manualStatus = status;
+
+                                if (status === "paid") {
+                                        const paidAt = update.paymentDate
+                                                ? new Date(update.paymentDate)
+                                                : new Date();
+
+                                        if (!Number.isNaN(paidAt.getTime())) {
+                                                setDoc.manualPaidAt = paidAt;
+                                        }
+                                } else {
+                                        setDoc.manualPaidAt = null;
+                                }
+                        }
+
+                        if (!status && update.paymentDate) {
+                                const manualDate = new Date(update.paymentDate);
+                                if (!Number.isNaN(manualDate.getTime())) {
+                                        setDoc.manualPaidAt = manualDate;
+                                }
+                        }
+
+                        if (typeof update.reference === "string") {
+                                const reference = update.reference.trim();
+                                setDoc.manualPayoutReference = reference || null;
+                        }
+
+                        if (typeof update.notes === "string") {
+                                setDoc.manualNotes = update.notes;
+                        }
+
+                        if (Object.keys(setDoc).length > 0) {
+                                updateDoc.$set = setDoc;
+                        }
+
+                        const amountNumber =
+                                typeof update.amount === "number"
+                                        ? update.amount
+                                        : typeof update.amount === "string" && update.amount.trim() !== ""
+                                        ? Number.parseFloat(update.amount)
+                                        : null;
+
+                        const shouldRecordHistory =
+                                Boolean(status) ||
+                                amountNumber !== null ||
+                                (typeof update.reference === "string" && update.reference.trim() !== "") ||
+                                (typeof update.notes === "string" && update.notes.trim() !== "") ||
+                                Boolean(update.paymentDate);
+
+                        if (shouldRecordHistory) {
+                                const processedAtDate = update.paymentDate
+                                        ? new Date(update.paymentDate)
+                                        : new Date();
+
+                                const historyEntry = {
+                                        status: status || undefined,
+                                        amount:
+                                                Number.isFinite(amountNumber) && !Number.isNaN(amountNumber)
+                                                        ? amountNumber
+                                                        : undefined,
+                                        reference:
+                                                typeof update.reference === "string"
+                                                        ? update.reference.trim() || undefined
+                                                        : undefined,
+                                        processedAt: Number.isNaN(processedAtDate.getTime())
+                                                ? new Date()
+                                                : processedAtDate,
+                                        processedBy: admin?.id ? toObjectId(admin.id) : null,
+                                        processedByName: [admin?.firstName, admin?.lastName]
+                                                .filter(Boolean)
+                                                .join(" "),
+                                        remarks:
+                                                typeof update.notes === "string"
+                                                        ? update.notes.trim() || undefined
+                                                        : undefined,
+                                };
+
+                                const cleanedHistory = Object.fromEntries(
+                                        Object.entries(historyEntry).filter(
+                                                ([, value]) =>
+                                                        value !== undefined && value !== null && value !== ""
+                                        )
+                                );
+
+                                if (Object.keys(cleanedHistory).length > 0) {
+                                        updateDoc.$push = {
+                                                manualHistory: cleanedHistory,
+                                        };
+                                }
+                        }
+
+                        if (Object.keys(updateDoc).length === 0) {
+                                continue;
+                        }
+
+                        const result = await Payment.updateMany(query, updateDoc);
+                        modifiedCount += result?.modifiedCount || 0;
+                        processedSellers.add(update.sellerId);
+                }
+
+                return NextResponse.json({
+                        success: true,
+                        modifiedCount,
+                        processed: processedSellers.size,
+                });
+        } catch (error) {
+                console.error("Error updating manual payouts:", error);
+                return NextResponse.json(
+                        {
+                                success: false,
+                                message: error.message || "Failed to update manual payouts",
+                        },
+                        { status: 500 }
+                );
+        }
+}

--- a/components/AdminPanel/PaymentsPage.jsx
+++ b/components/AdminPanel/PaymentsPage.jsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "react-hot-toast";
+import {
+        Card,
+        CardContent,
+        CardHeader,
+        CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -22,6 +28,17 @@ import {
         TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
         IndianRupee,
         ShieldCheck,
@@ -30,9 +47,13 @@ import {
         Calendar,
         Search,
         RotateCcw,
+        Download,
+        ListChecks,
+        ClipboardCheck,
 } from "lucide-react";
 
 import { useAdminPaymentStore } from "@/store/adminPaymentStore.js";
+import { useAdminManualPayoutStore } from "@/store/adminManualPayoutStore.js";
 import { useIsAuthenticated } from "@/store/adminAuthStore.js";
 
 const STATUS_OPTIONS = [
@@ -44,12 +65,33 @@ const STATUS_OPTIONS = [
         { label: "Disputed", value: "disputed" },
 ];
 
+const MANUAL_STATUS_OPTIONS = [
+        { label: "All", value: "all" },
+        { label: "Pending", value: "pending" },
+        { label: "Scheduled", value: "scheduled" },
+        { label: "Paid", value: "paid" },
+];
+
 const statusStyles = {
         escrow: "bg-amber-100 text-amber-800",
         released: "bg-emerald-100 text-emerald-800",
         refunded: "bg-red-100 text-red-800",
         cancelled: "bg-gray-100 text-gray-800",
         disputed: "bg-purple-100 text-purple-800",
+};
+
+const manualStatusStyles = {
+        pending: "bg-orange-100 text-orange-700",
+        scheduled: "bg-blue-100 text-blue-700",
+        paid: "bg-emerald-100 text-emerald-700",
+};
+
+const initialManualUpdateForm = {
+        status: "scheduled",
+        paymentDate: "",
+        reference: "",
+        amount: "",
+        notes: "",
 };
 
 const formatCurrency = (value) => {
@@ -94,9 +136,28 @@ const getSellerDisplay = (payment) => {
         return { name, email };
 };
 
+const getBankDisplay = (bankDetails) => {
+        if (!bankDetails) {
+                return "No bank details";
+        }
+
+        const parts = [
+                bankDetails.accountHolderName,
+                bankDetails.bankName,
+                bankDetails.accountNumber ? `A/C ${bankDetails.accountNumber}` : null,
+                bankDetails.ifscCode ? `IFSC ${bankDetails.ifscCode}` : null,
+                bankDetails.upiId ? `UPI ${bankDetails.upiId}` : null,
+        ].filter(Boolean);
+
+        return parts.join(" • ");
+};
+
 function AdminPaymentsPage() {
         const router = useRouter();
         const isAuthenticated = useIsAuthenticated();
+        const [activeTab, setActiveTab] = useState("escrow");
+        const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
+        const [manualUpdateForm, setManualUpdateForm] = useState(initialManualUpdateForm);
 
         const {
                 payments,
@@ -108,7 +169,53 @@ function AdminPaymentsPage() {
                 setFilters,
                 resetFilters,
                 fetchPayments,
-        } = useAdminPaymentStore();
+        } = useAdminPaymentStore((state) => ({
+                payments: state.payments,
+                loading: state.loading,
+                error: state.error,
+                stats: state.stats,
+                pagination: state.pagination,
+                filters: state.filters,
+                setFilters: state.setFilters,
+                resetFilters: state.resetFilters,
+                fetchPayments: state.fetchPayments,
+        }));
+
+        const {
+                sellers: manualSellers,
+                loading: manualLoading,
+                error: manualError,
+                stats: manualStats,
+                pagination: manualPagination,
+                filters: manualFilters,
+                selectedSellerIds,
+                setFilters: setManualFilters,
+                resetFilters: resetManualFilters,
+                fetchSellers: fetchManualSellers,
+                toggleSellerSelection,
+                selectAllOnPage,
+                clearSelection,
+                downloadCsv,
+                bulkUpdateStatus,
+                updating: manualUpdating,
+        } = useAdminManualPayoutStore((state) => ({
+                sellers: state.sellers,
+                loading: state.loading,
+                error: state.error,
+                stats: state.stats,
+                pagination: state.pagination,
+                filters: state.filters,
+                selectedSellerIds: state.selectedSellerIds,
+                setFilters: state.setFilters,
+                resetFilters: state.resetFilters,
+                fetchSellers: state.fetchSellers,
+                toggleSellerSelection: state.toggleSellerSelection,
+                selectAllOnPage: state.selectAllOnPage,
+                clearSelection: state.clearSelection,
+                downloadCsv: state.downloadCsv,
+                bulkUpdateStatus: state.bulkUpdateStatus,
+                updating: state.updating,
+        }));
 
         useEffect(() => {
                 if (!isAuthenticated) {
@@ -118,13 +225,23 @@ function AdminPaymentsPage() {
         }, [isAuthenticated, router]);
 
         useEffect(() => {
-                if (isAuthenticated) {
+                if (isAuthenticated && activeTab === "escrow") {
                         fetchPayments();
                 }
-        }, [filters, fetchPayments, isAuthenticated]);
+        }, [isAuthenticated, activeTab, filters, fetchPayments]);
+
+        useEffect(() => {
+                if (isAuthenticated && activeTab === "manual") {
+                        fetchManualSellers();
+                }
+        }, [isAuthenticated, activeTab, manualFilters, fetchManualSellers]);
 
         const handleFilterChange = (key, value) => {
                 setFilters({ [key]: value, page: 1 });
+        };
+
+        const handleManualFilterChange = (key, value) => {
+                setManualFilters({ [key]: value, page: 1 });
         };
 
         const handleSearchSubmit = (event) => {
@@ -134,10 +251,78 @@ function AdminPaymentsPage() {
                 setFilters({ search: searchValue.trim(), page: 1 });
         };
 
+        const handleManualSearchSubmit = (event) => {
+                event.preventDefault();
+                const formData = new FormData(event.currentTarget);
+                const searchValue = formData.get("search")?.toString() || "";
+                setManualFilters({ search: searchValue.trim(), page: 1 });
+        };
+
         const handlePageChange = (page) => {
                 if (page < 1 || page > pagination.totalPages) return;
                 setFilters({ page });
         };
+
+        const handleManualPageChange = (page) => {
+                if (page < 1 || page > manualPagination.totalPages) return;
+                setManualFilters({ page });
+        };
+
+        const handleDownloadManualCsv = async () => {
+                try {
+                        await downloadCsv();
+                        toast.success("Manual payout report downloaded");
+                } catch (downloadError) {
+                        toast.error(downloadError.message || "Failed to download report");
+                }
+        };
+
+        const handleOpenManualUpdate = () => {
+                if (selectedSellerIds.length === 0) {
+                        toast.error("Select at least one seller");
+                        return;
+                }
+                setIsUpdateDialogOpen(true);
+        };
+
+        const handleManualUpdateSubmit = async (event) => {
+                event.preventDefault();
+
+                const payload = {
+                        sellerIds: selectedSellerIds,
+                        status: manualUpdateForm.status,
+                        paymentDate: manualUpdateForm.paymentDate || null,
+                        reference: manualUpdateForm.reference.trim() || null,
+                        amount:
+                                manualUpdateForm.amount && !Number.isNaN(Number.parseFloat(manualUpdateForm.amount))
+                                        ? Number.parseFloat(manualUpdateForm.amount)
+                                        : null,
+                        notes: manualUpdateForm.notes.trim() || "",
+                };
+
+                try {
+                        await bulkUpdateStatus(payload);
+                        toast.success(`Updated manual payouts for ${selectedSellerIds.length} seller${
+                                selectedSellerIds.length > 1 ? "s" : ""
+                        }`);
+                        setManualUpdateForm(initialManualUpdateForm);
+                        setIsUpdateDialogOpen(false);
+                } catch (updateError) {
+                        toast.error(updateError.message || "Failed to update manual payouts");
+                }
+        };
+
+        const manualSelectionState = useMemo(() => {
+                const allSelected =
+                        manualSellers.length > 0 &&
+                        manualSellers.every((seller) => selectedSellerIds.includes(seller.sellerId));
+                const partiallySelected =
+                        selectedSellerIds.length > 0 && !allSelected && manualSellers.some((seller) => selectedSellerIds.includes(seller.sellerId));
+
+                if (allSelected) return true;
+                if (partiallySelected) return "indeterminate";
+                return false;
+        }, [manualSellers, selectedSellerIds]);
 
         if (!isAuthenticated) {
                 return (
@@ -153,259 +338,654 @@ function AdminPaymentsPage() {
                                 initial={{ opacity: 0, y: 20 }}
                                 animate={{ opacity: 1, y: 0 }}
                                 transition={{ duration: 0.3 }}
+                                className="space-y-2"
                         >
-                                <h1 className="text-3xl font-bold text-gray-900">Payment Escrow & Settlements</h1>
-                                <p className="text-gray-600 mt-2">
-                                        Monitor Razorpay collections, escrow balances, and automatic payouts released to sellers.
+                                <h1 className="text-3xl font-bold text-gray-900">Payment Operations Center</h1>
+                                <p className="text-gray-600">
+                                        Switch between Razorpay escrow settlements and manual seller payouts to keep every
+                                        disbursement on track.
                                 </p>
                         </motion.div>
 
-                        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-                                <Card>
-                                        <CardContent className="p-6">
-                                                <div className="flex items-center">
-                                                        <IndianRupee className="h-8 w-8 text-indigo-600" />
-                                                        <div className="ml-4">
-                                                                <p className="text-sm font-medium text-gray-600">Commission Earned</p>
-                                                                <p className="text-2xl font-bold text-gray-900">
-                                                                        {formatCurrency(stats.commissionEarned)}
-                                                                </p>
-                                                        </div>
-                                                </div>
-                                        </CardContent>
-                                </Card>
-                                <Card>
-                                        <CardContent className="p-6">
-                                                <div className="flex items-center">
-                                                        <ShieldCheck className="h-8 w-8 text-emerald-600" />
-                                                        <div className="ml-4">
-                                                                <p className="text-sm font-medium text-gray-600">In Escrow</p>
-                                                                <p className="text-2xl font-bold text-gray-900">
-                                                                        {formatCurrency(stats.escrowAmount)}
-                                                                </p>
-                                                        </div>
-                                                </div>
-                                        </CardContent>
-                                </Card>
-                                <Card>
-                                        <CardContent className="p-6">
-                                                <div className="flex items-center">
-                                                        <Wallet className="h-8 w-8 text-blue-600" />
-                                                        <div className="ml-4">
-                                                                <p className="text-sm font-medium text-gray-600">Released to Sellers</p>
-                                                                <p className="text-2xl font-bold text-gray-900">
-                                                                        {formatCurrency(stats.releasedAmount)}
-                                                                </p>
-                                                        </div>
-                                                </div>
-                                        </CardContent>
-                                </Card>
-                                <Card>
-                                        <CardContent className="p-6">
-                                                <div className="flex items-center">
-                                                        <Users className="h-8 w-8 text-orange-500" />
-                                                        <div className="ml-4">
-                                                                <p className="text-sm font-medium text-gray-600">Total Settlements</p>
-                                                                <p className="text-2xl font-bold text-gray-900">{stats.totalOrders}</p>
-                                                        </div>
-                                                </div>
-                                        </CardContent>
-                                </Card>
-                        </div>
+                        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+                                <TabsList>
+                                        <TabsTrigger value="escrow">Escrow Settlements</TabsTrigger>
+                                        <TabsTrigger value="manual">Manual Payouts</TabsTrigger>
+                                </TabsList>
 
-                        <Card>
-                                <CardHeader className="pb-2">
-                                        <CardTitle className="text-xl font-semibold">Razorpay Payment History</CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-6">
-                                        <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
-                                                <form
-                                                        onSubmit={handleSearchSubmit}
-                                                        className="col-span-12 lg:col-span-4 flex items-center space-x-2"
-                                                >
-                                                        <div className="relative flex-1">
-                                                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-                                                                <Input
-                                                                        name="search"
-                                                                        defaultValue={filters.search}
-                                                                        placeholder="Search order number or seller"
-                                                                        className="pl-9"
-                                                                />
-                                                        </div>
-                                                        <Button type="submit" variant="outline">
-                                                                Search
-                                                        </Button>
-                                                </form>
-                                                <div className="col-span-6 lg:col-span-3">
-                                                        <Select
-                                                                value={filters.status}
-                                                                onValueChange={(value) => handleFilterChange("status", value)}
-                                                        >
-                                                                <SelectTrigger>
-                                                                        <SelectValue placeholder="Status" />
-                                                                </SelectTrigger>
-                                                                <SelectContent>
-                                                                        {STATUS_OPTIONS.map((option) => (
-                                                                                <SelectItem key={option.value} value={option.value}>
-                                                                                        {option.label}
-                                                                                </SelectItem>
-                                                                        ))}
-                                                                </SelectContent>
-                                                        </Select>
-                                                </div>
-                                                <div className="col-span-6 lg:col-span-2">
-                                                        <Input
-                                                                placeholder="Seller ID"
-                                                                defaultValue={filters.sellerId}
-                                                                onBlur={(event) =>
-                                                                        handleFilterChange("sellerId", event.target.value.trim())
-                                                                }
-                                                        />
-                                                </div>
-                                                <div className="col-span-6 lg:col-span-2">
-                                                        <div className="flex items-center gap-2">
-                                                                <Calendar className="h-4 w-4 text-gray-500" />
-                                                                <Input
-                                                                        type="date"
-                                                                        value={filters.startDate}
-                                                                        onChange={(event) => handleFilterChange("startDate", event.target.value)}
-                                                                />
-                                                        </div>
-                                                </div>
-                                                <div className="col-span-6 lg:col-span-1">
-                                                        <Input
-                                                                type="date"
-                                                                value={filters.endDate}
-                                                                onChange={(event) => handleFilterChange("endDate", event.target.value)}
-                                                        />
-                                                </div>
-                                                <div className="col-span-6 lg:col-span-1 flex justify-end">
-                                                        <Button type="button" variant="outline" className="w-full" onClick={() => resetFilters()}>
-                                                                <RotateCcw className="h-4 w-4 mr-2" />
-                                                                Reset
-                                                        </Button>
-                                                </div>
+                                <TabsContent value="escrow" className="space-y-6">
+                                        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <IndianRupee className="h-8 w-8 text-indigo-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Commission Earned</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(stats.commissionEarned)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <ShieldCheck className="h-8 w-8 text-emerald-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">In Escrow</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(stats.escrowAmount)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <Wallet className="h-8 w-8 text-blue-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Released to Sellers</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(stats.releasedAmount)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <Users className="h-8 w-8 text-orange-500" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Total Settlements</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">{stats.totalOrders}</p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
                                         </div>
 
-                                        <div className="overflow-x-auto">
-                                                <Table>
-                                                        <TableHeader>
-                                                                <TableRow>
-                                                                        <TableHead>Order</TableHead>
-                                                                        <TableHead>Seller</TableHead>
-                                                                        <TableHead>Status</TableHead>
-                                                                        <TableHead>Total</TableHead>
-                                                                        <TableHead>Seller Share</TableHead>
-                                                                        <TableHead>Commission</TableHead>
-                                                                        <TableHead>Escrow Date</TableHead>
-                                                                        <TableHead>Released</TableHead>
-                                                                        <TableHead>Reference</TableHead>
-                                                                </TableRow>
-                                                        </TableHeader>
-                                                        <TableBody>
-                                                                {loading && (
-                                                                        <TableRow>
-                                                                                <TableCell colSpan={9} className="text-center py-6 text-gray-500">
-                                                                                        Loading payments...
-                                                                                </TableCell>
-                                                                        </TableRow>
-                                                                )}
-                                                                {!loading && error && (
-                                                                        <TableRow>
-                                                                                <TableCell colSpan={9} className="text-center py-6 text-red-500">
-                                                                                        {error}
-                                                                                </TableCell>
-                                                                        </TableRow>
-                                                                )}
-                                                                {!loading && !error && payments.length === 0 && (
-                                                                        <TableRow>
-                                                                                <TableCell colSpan={9} className="text-center py-8 text-gray-500">
-                                                                                        No payment activity found for the selected filters.
-                                                                                </TableCell>
-                                                                        </TableRow>
-                                                                )}
-                                                                {!loading && !error &&
-                                                                        payments.map((payment) => {
-                                                                                const seller = getSellerDisplay(payment);
-                                                                                return (
-                                                                                        <TableRow key={payment._id}>
-                                                                                                <TableCell>
-                                                                                                        <div className="font-semibold text-gray-900">
-                                                                                                                {payment.orderNumber}
-                                                                                                        </div>
-                                                                                                        <div className="text-xs text-gray-500">
-                                                                                                                {formatSubOrderReference(payment.subOrderId)}
-                                                                                                        </div>
-                                                                                                </TableCell>
-                                                                                                <TableCell>
-                                                                                                        <div className="font-medium text-gray-900">{seller.name}</div>
-                                                                                                        {seller.email && (
-                                                                                                                <div className="text-xs text-gray-500">{seller.email}</div>
-                                                                                                        )}
-                                                                                                </TableCell>
-                                                                                                <TableCell>
-                                                                                                        <Badge className={statusStyles[payment.status] || "bg-gray-100 text-gray-800"}>
-                                                                                                                {payment.status.charAt(0).toUpperCase() + payment.status.slice(1)}
-                                                                                                        </Badge>
-                                                                                                </TableCell>
-                                                                                                <TableCell>{formatCurrency(payment.totalAmount)}</TableCell>
-                                                                                                <TableCell>{formatCurrency(payment.sellerAmount)}</TableCell>
-                                                                                                <TableCell>{formatCurrency(payment.commissionAmount)}</TableCell>
-                                                                                                <TableCell>{formatDate(payment.escrowActivatedAt || payment.createdAt)}</TableCell>
-                                                                                                <TableCell>{formatDate(payment.releasedAt)}</TableCell>
-                                                                                                <TableCell className="text-xs text-gray-500">
-                                                                                                        {payment.razorpayPaymentId || payment.razorpayOrderId || "--"}
+                                        <Card>
+                                                <CardHeader className="pb-2">
+                                                        <CardTitle className="text-xl font-semibold">Razorpay Payment History</CardTitle>
+                                                </CardHeader>
+                                                <CardContent className="space-y-6">
+                                                        <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
+                                                                <form
+                                                                        onSubmit={handleSearchSubmit}
+                                                                        className="col-span-12 lg:col-span-4 flex items-center space-x-2"
+                                                                >
+                                                                        <div className="relative flex-1">
+                                                                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                                                                <Input
+                                                                                        name="search"
+                                                                                        defaultValue={filters.search}
+                                                                                        placeholder="Search order number or seller"
+                                                                                        className="pl-9"
+                                                                                />
+                                                                        </div>
+                                                                        <Button type="submit" variant="outline">
+                                                                                Search
+                                                                        </Button>
+                                                                </form>
+                                                                <div className="col-span-6 lg:col-span-3">
+                                                                        <Select
+                                                                                value={filters.status}
+                                                                                onValueChange={(value) => handleFilterChange("status", value)}
+                                                                        >
+                                                                                <SelectTrigger>
+                                                                                        <SelectValue placeholder="Status" />
+                                                                                </SelectTrigger>
+                                                                                <SelectContent>
+                                                                                        {STATUS_OPTIONS.map((option) => (
+                                                                                                <SelectItem key={option.value} value={option.value}>
+                                                                                                        {option.label}
+                                                                                                </SelectItem>
+                                                                                        ))}
+                                                                                </SelectContent>
+                                                                        </Select>
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-2">
+                                                                        <Input
+                                                                                placeholder="Seller ID"
+                                                                                defaultValue={filters.sellerId}
+                                                                                onBlur={(event) => handleFilterChange("sellerId", event.target.value.trim())}
+                                                                        />
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-2">
+                                                                        <div className="flex items-center gap-2">
+                                                                                <Calendar className="h-4 w-4 text-gray-500" />
+                                                                                <Input
+                                                                                        type="date"
+                                                                                        value={filters.startDate}
+                                                                                        onChange={(event) => handleFilterChange("startDate", event.target.value)}
+                                                                                />
+                                                                        </div>
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-1">
+                                                                        <Input
+                                                                                type="date"
+                                                                                value={filters.endDate}
+                                                                                onChange={(event) => handleFilterChange("endDate", event.target.value)}
+                                                                        />
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-1 flex justify-end">
+                                                                        <Button type="button" variant="outline" className="w-full" onClick={() => resetFilters()}>
+                                                                                <RotateCcw className="h-4 w-4 mr-2" />
+                                                                                Reset
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+
+                                                        <div className="overflow-x-auto">
+                                                                <Table>
+                                                                        <TableHeader>
+                                                                                <TableRow>
+                                                                                        <TableHead>Order</TableHead>
+                                                                                        <TableHead>Seller</TableHead>
+                                                                                        <TableHead>Status</TableHead>
+                                                                                        <TableHead>Total</TableHead>
+                                                                                        <TableHead>Seller Share</TableHead>
+                                                                                        <TableHead>Commission</TableHead>
+                                                                                        <TableHead>Escrow Date</TableHead>
+                                                                                        <TableHead>Released</TableHead>
+                                                                                        <TableHead>Reference</TableHead>
+                                                                                </TableRow>
+                                                                        </TableHeader>
+                                                                        <TableBody>
+                                                                                {loading && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={9} className="text-center py-6 text-gray-500">
+                                                                                                        Loading payments...
                                                                                                 </TableCell>
                                                                                         </TableRow>
+                                                                                )}
+                                                                                {!loading && error && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={9} className="text-center py-6 text-red-500">
+                                                                                                        {error}
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                )}
+                                                                                {!loading && !error && payments.length === 0 && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={9} className="text-center py-8 text-gray-500">
+                                                                                                        No payment activity found for the selected filters.
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                )}
+                                                                                {!loading && !error &&
+                                                                                        payments.map((payment) => {
+                                                                                                const seller = getSellerDisplay(payment);
+                                                                                                return (
+                                                                                                        <TableRow key={payment._id}>
+                                                                                                                <TableCell>
+                                                                                                                        <div className="font-semibold text-gray-900">
+                                                                                                                                {payment.orderNumber}
+                                                                                                                        </div>
+                                                                                                                        <div className="text-xs text-gray-500">
+                                                                                                                                {formatSubOrderReference(payment.subOrderId)}
+                                                                                                                        </div>
+                                                                                                                </TableCell>
+                                                                                                                <TableCell>
+                                                                                                                        <div className="font-medium text-gray-900">{seller.name}</div>
+                                                                                                                        {seller.email && (
+                                                                                                                                <div className="text-xs text-gray-500">{seller.email}</div>
+                                                                                                                        )}
+                                                                                                                </TableCell>
+                                                                                                                <TableCell>
+                                                                                                                        <Badge className={statusStyles[payment.status] || "bg-gray-100 text-gray-800"}>
+                                                                                                                                {payment.status.charAt(0).toUpperCase() + payment.status.slice(1)}
+                                                                                                                        </Badge>
+                                                                                                                </TableCell>
+                                                                                                                <TableCell>{formatCurrency(payment.totalAmount)}</TableCell>
+                                                                                                                <TableCell>{formatCurrency(payment.sellerAmount)}</TableCell>
+                                                                                                                <TableCell>{formatCurrency(payment.commissionAmount)}</TableCell>
+                                                                                                                <TableCell>{formatDate(payment.escrowActivatedAt || payment.createdAt)}</TableCell>
+                                                                                                                <TableCell>{formatDate(payment.releasedAt)}</TableCell>
+                                                                                                                <TableCell className="text-xs text-gray-500">
+                                                                                                                        {payment.razorpayPaymentId || payment.razorpayOrderId || "--"}
+                                                                                                                </TableCell>
+                                                                                                        </TableRow>
+                                                                                                );
+                                                                                        })}
+                                                                        </TableBody>
+                                                                </Table>
+                                                        </div>
+
+                                                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                                                                <p className="text-sm text-gray-600">
+                                                                        Showing page {pagination.currentPage} of {pagination.totalPages} — {" "}
+                                                                        {pagination.totalRecords} records
+                                                                </p>
+                                                                <div className="flex gap-2">
+                                                                        <Button
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                disabled={!pagination.hasPrev}
+                                                                                onClick={() => handlePageChange(pagination.currentPage - 1)}
+                                                                        >
+                                                                                Previous
+                                                                        </Button>
+                                                                        {Array.from({ length: Math.min(5, pagination.totalPages) }, (_, index) => {
+                                                                                const pageNumber = index + 1;
+                                                                                return (
+                                                                                        <Button
+                                                                                                key={pageNumber}
+                                                                                                size="sm"
+                                                                                                variant={
+                                                                                                        pagination.currentPage === pageNumber
+                                                                                                                ? "default"
+                                                                                                                : "outline"
+                                                                                                }
+                                                                                                onClick={() => handlePageChange(pageNumber)}
+                                                                                        >
+                                                                                                {pageNumber}
+                                                                                        </Button>
                                                                                 );
                                                                         })}
-                                                        </TableBody>
-                                                </Table>
+                                                                        <Button
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                disabled={!pagination.hasNext}
+                                                                                onClick={() => handlePageChange(pagination.currentPage + 1)}
+                                                                        >
+                                                                                Next
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                </CardContent>
+                                        </Card>
+                                </TabsContent>
+
+                                <TabsContent value="manual" className="space-y-6">
+                                        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <Users className="h-8 w-8 text-indigo-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Sellers in Manual Cycle</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {manualStats.totalSellers}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <Wallet className="h-8 w-8 text-orange-500" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Pending Payout</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(manualStats.pendingAmount)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <ShieldCheck className="h-8 w-8 text-blue-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Scheduled</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(manualStats.scheduledAmount)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
+                                                <Card>
+                                                        <CardContent className="p-6">
+                                                                <div className="flex items-center">
+                                                                        <IndianRupee className="h-8 w-8 text-emerald-600" />
+                                                                        <div className="ml-4">
+                                                                                <p className="text-sm font-medium text-gray-600">Paid Out</p>
+                                                                                <p className="text-2xl font-bold text-gray-900">
+                                                                                        {formatCurrency(manualStats.paidAmount)}
+                                                                                </p>
+                                                                        </div>
+                                                                </div>
+                                                        </CardContent>
+                                                </Card>
                                         </div>
 
-                                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                                                <p className="text-sm text-gray-600">
-                                                        Showing page {pagination.currentPage} of {pagination.totalPages} — {" "}
-                                                        {pagination.totalRecords} records
-                                                </p>
-                                                <div className="flex gap-2">
-                                                        <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                disabled={!pagination.hasPrev}
-                                                                onClick={() => handlePageChange(pagination.currentPage - 1)}
-                                                        >
-                                                                Previous
-                                                        </Button>
-                                                        {Array.from({ length: Math.min(5, pagination.totalPages) }, (_, index) => {
-                                                                const pageNumber = index + 1;
-                                                                return (
-                                                                        <Button
-                                                                                key={pageNumber}
-                                                                                size="sm"
-                                                                                variant={
-                                                                                        pagination.currentPage === pageNumber
-                                                                                                ? "default"
-                                                                                                : "outline"
-                                                                                }
-                                                                                onClick={() => handlePageChange(pageNumber)}
-                                                                        >
-                                                                                {pageNumber}
+                                        <Card>
+                                                <CardHeader className="pb-2">
+                                                        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                                                                <CardTitle className="text-xl font-semibold">
+                                                                        Manual Seller Payouts
+                                                                </CardTitle>
+                                                                <div className="flex flex-wrap gap-2">
+                                                                        <Button variant="outline" onClick={handleDownloadManualCsv}>
+                                                                                <Download className="mr-2 h-4 w-4" /> Download CSV
                                                                         </Button>
-                                                                );
-                                                        })}
-                                                        <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                disabled={!pagination.hasNext}
-                                                                onClick={() => handlePageChange(pagination.currentPage + 1)}
-                                                        >
-                                                                Next
-                                                        </Button>
+                                                                        <Button onClick={handleOpenManualUpdate} disabled={selectedSellerIds.length === 0}>
+                                                                                <ListChecks className="mr-2 h-4 w-4" /> Update Status
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                </CardHeader>
+                                                <CardContent className="space-y-6">
+                                                        <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
+                                                                <form
+                                                                        onSubmit={handleManualSearchSubmit}
+                                                                        className="col-span-12 lg:col-span-4 flex items-center space-x-2"
+                                                                >
+                                                                        <div className="relative flex-1">
+                                                                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                                                                <Input
+                                                                                        name="search"
+                                                                                        defaultValue={manualFilters.search}
+                                                                                        placeholder="Search seller name or email"
+                                                                                        className="pl-9"
+                                                                                />
+                                                                        </div>
+                                                                        <Button type="submit" variant="outline">
+                                                                                Search
+                                                                        </Button>
+                                                                </form>
+                                                                <div className="col-span-6 lg:col-span-3">
+                                                                        <Select
+                                                                                value={manualFilters.status}
+                                                                                onValueChange={(value) => handleManualFilterChange("status", value)}
+                                                                        >
+                                                                                <SelectTrigger>
+                                                                                        <SelectValue placeholder="Status" />
+                                                                                </SelectTrigger>
+                                                                                <SelectContent>
+                                                                                        {MANUAL_STATUS_OPTIONS.map((option) => (
+                                                                                                <SelectItem key={option.value} value={option.value}>
+                                                                                                        {option.label}
+                                                                                                </SelectItem>
+                                                                                        ))}
+                                                                                </SelectContent>
+                                                                        </Select>
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-2">
+                                                                        <Input
+                                                                                type="date"
+                                                                                value={manualFilters.startDate || ""}
+                                                                                onChange={(event) => handleManualFilterChange("startDate", event.target.value)}
+                                                                        />
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-2">
+                                                                        <Input
+                                                                                type="date"
+                                                                                value={manualFilters.endDate || ""}
+                                                                                onChange={(event) => handleManualFilterChange("endDate", event.target.value)}
+                                                                        />
+                                                                </div>
+                                                                <div className="col-span-6 lg:col-span-1 flex justify-end">
+                                                                        <Button type="button" variant="outline" className="w-full" onClick={() => resetManualFilters()}>
+                                                                                <RotateCcw className="h-4 w-4 mr-2" />
+                                                                                Reset
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+
+                                                        <div className="overflow-x-auto">
+                                                                <Table>
+                                                                        <TableHeader>
+                                                                                <TableRow>
+                                                                                        <TableHead className="w-12">
+                                                                                                <Checkbox
+                                                                                                        checked={manualSelectionState}
+                                                                                                        onCheckedChange={(checked) => {
+                                                                                                                if (checked) {
+                                                                                                                        selectAllOnPage();
+                                                                                                                } else {
+                                                                                                                        clearSelection();
+                                                                                                                }
+                                                                                                        }}
+                                                                                                        aria-label="Select all sellers"
+                                                                                                />
+                                                                                        </TableHead>
+                                                                                        <TableHead>Seller</TableHead>
+                                                                                        <TableHead>Status</TableHead>
+                                                                                        <TableHead>Pending</TableHead>
+                                                                                        <TableHead>Scheduled</TableHead>
+                                                                                        <TableHead>Paid</TableHead>
+                                                                                        <TableHead>Total Orders</TableHead>
+                                                                                        <TableHead>Last Order</TableHead>
+                                                                                        <TableHead>Bank Details</TableHead>
+                                                                                        <TableHead>Notes</TableHead>
+                                                                                </TableRow>
+                                                                        </TableHeader>
+                                                                        <TableBody>
+                                                                                {manualLoading && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={10} className="text-center py-6 text-gray-500">
+                                                                                                        Loading manual payouts...
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                )}
+                                                                                {!manualLoading && manualError && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={10} className="text-center py-6 text-red-500">
+                                                                                                        {manualError}
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                )}
+                                                                                {!manualLoading && !manualError && manualSellers.length === 0 && (
+                                                                                        <TableRow>
+                                                                                                <TableCell colSpan={10} className="text-center py-8 text-gray-500">
+                                                                                                        No manual payouts found for the selected filters.
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                )}
+                                                                                {!manualLoading && !manualError &&
+                                                                                        manualSellers.map((seller) => (
+                                                                                                <TableRow key={seller.sellerId}>
+                                                                                                        <TableCell>
+                                                                                                                <Checkbox
+                                                                                                                        checked={selectedSellerIds.includes(seller.sellerId)}
+                                                                                                                        onCheckedChange={(checked) =>
+                                                                                                                                toggleSellerSelection(seller.sellerId, checked === true)
+                                                                                                                        }
+                                                                                                                        aria-label={`Select seller ${
+                                                                                                                                seller.sellerSnapshot?.businessName || seller.sellerSnapshot?.name
+                                                                                                                        }`}
+                                                                                                                />
+                                                                                                        </TableCell>
+                                                                                                        <TableCell>
+                                                                                                                <div className="font-medium text-gray-900">
+                                                                                                                        {seller.sellerSnapshot?.businessName || seller.sellerSnapshot?.name || "Unknown Seller"}
+                                                                                                                </div>
+                                                                                                                {seller.sellerSnapshot?.email && (
+                                                                                                                        <div className="text-xs text-gray-500">
+                                                                                                                                {seller.sellerSnapshot.email}
+                                                                                                                        </div>
+                                                                                                                )}
+                                                                                                        </TableCell>
+                                                                                                        <TableCell>
+                                                                                                                <Badge className={manualStatusStyles[seller.status] || "bg-gray-100 text-gray-800"}>
+                                                                                                                        {seller.status.charAt(0).toUpperCase() + seller.status.slice(1)}
+                                                                                                                </Badge>
+                                                                                                        </TableCell>
+                                                                                                        <TableCell>{formatCurrency(seller.pendingAmount)}</TableCell>
+                                                                                                        <TableCell>{formatCurrency(seller.scheduledAmount)}</TableCell>
+                                                                                                        <TableCell>{formatCurrency(seller.paidAmount)}</TableCell>
+                                                                                                        <TableCell>{seller.totalOrders}</TableCell>
+                                                                                                        <TableCell>{formatDate(seller.lastOrderDate)}</TableCell>
+                                                                                                        <TableCell className="text-xs text-gray-600 max-w-xs">
+                                                                                                                {getBankDisplay(seller.bankDetails)}
+                                                                                                        </TableCell>
+                                                                                                        <TableCell className="text-xs text-gray-600 max-w-xs">
+                                                                                                                {seller.manualNotes || "—"}
+                                                                                                        </TableCell>
+                                                                                                </TableRow>
+                                                                                        ))}
+                                                                        </TableBody>
+                                                                </Table>
+                                                        </div>
+
+                                                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                                                                <p className="text-sm text-gray-600">
+                                                                        Showing page {manualPagination.currentPage} of {manualPagination.totalPages} — {" "}
+                                                                        {manualPagination.totalRecords} sellers
+                                                                </p>
+                                                                <div className="flex gap-2">
+                                                                        <Button
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                disabled={!manualPagination.hasPrev}
+                                                                                onClick={() => handleManualPageChange(manualPagination.currentPage - 1)}
+                                                                        >
+                                                                                Previous
+                                                                        </Button>
+                                                                        {Array.from({ length: Math.min(5, manualPagination.totalPages) }, (_, index) => {
+                                                                                const pageNumber = index + 1;
+                                                                                return (
+                                                                                        <Button
+                                                                                                key={pageNumber}
+                                                                                                size="sm"
+                                                                                                variant={
+                                                                                                        manualPagination.currentPage === pageNumber
+                                                                                                                ? "default"
+                                                                                                                : "outline"
+                                                                                                }
+                                                                                                onClick={() => handleManualPageChange(pageNumber)}
+                                                                                        >
+                                                                                                {pageNumber}
+                                                                                        </Button>
+                                                                                );
+                                                                        })}
+                                                                        <Button
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                disabled={!manualPagination.hasNext}
+                                                                                onClick={() => handleManualPageChange(manualPagination.currentPage + 1)}
+                                                                        >
+                                                                                Next
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                </CardContent>
+                                        </Card>
+                                </TabsContent>
+                        </Tabs>
+
+                        <Dialog open={isUpdateDialogOpen} onOpenChange={setIsUpdateDialogOpen}>
+                                <DialogContent>
+                                        <form onSubmit={handleManualUpdateSubmit} className="space-y-4">
+                                                <DialogHeader>
+                                                        <DialogTitle>Update manual payouts</DialogTitle>
+                                                        <DialogDescription>
+                                                                Apply a payout status update to {selectedSellerIds.length} selected seller
+                                                                {selectedSellerIds.length > 1 ? "s" : ""}.
+                                                        </DialogDescription>
+                                                </DialogHeader>
+
+                                                <div className="grid grid-cols-1 gap-4">
+                                                        <div>
+                                                                <label className="text-sm font-medium text-gray-700">Status</label>
+                                                                <Select
+                                                                        value={manualUpdateForm.status}
+                                                                        onValueChange={(value) =>
+                                                                                setManualUpdateForm((prev) => ({ ...prev, status: value }))
+                                                                        }
+                                                                >
+                                                                        <SelectTrigger className="mt-1">
+                                                                                <SelectValue placeholder="Select status" />
+                                                                        </SelectTrigger>
+                                                                        <SelectContent>
+                                                                                {MANUAL_STATUS_OPTIONS.filter((option) => option.value !== "all").map(
+                                                                                        (option) => (
+                                                                                                <SelectItem key={option.value} value={option.value}>
+                                                                                                        {option.label}
+                                                                                                </SelectItem>
+                                                                                        )
+                                                                                )}
+                                                                        </SelectContent>
+                                                                </Select>
+                                                        </div>
+                                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                                <div>
+                                                                        <label className="text-sm font-medium text-gray-700">Payment date</label>
+                                                                        <Input
+                                                                                type="date"
+                                                                                value={manualUpdateForm.paymentDate}
+                                                                                onChange={(event) =>
+                                                                                        setManualUpdateForm((prev) => ({
+                                                                                                ...prev,
+                                                                                                paymentDate: event.target.value,
+                                                                                        }))
+                                                                                }
+                                                                                className="mt-1"
+                                                                        />
+                                                                </div>
+                                                                <div>
+                                                                        <label className="text-sm font-medium text-gray-700">Reference / UTR</label>
+                                                                        <Input
+                                                                                value={manualUpdateForm.reference}
+                                                                                onChange={(event) =>
+                                                                                        setManualUpdateForm((prev) => ({
+                                                                                                ...prev,
+                                                                                                reference: event.target.value,
+                                                                                        }))
+                                                                                }
+                                                                                placeholder="Bank reference number"
+                                                                                className="mt-1"
+                                                                        />
+                                                                </div>
+                                                        </div>
+                                                        <div>
+                                                                <label className="text-sm font-medium text-gray-700">Amount (optional)</label>
+                                                                <Input
+                                                                        value={manualUpdateForm.amount}
+                                                                        onChange={(event) =>
+                                                                                setManualUpdateForm((prev) => ({
+                                                                                        ...prev,
+                                                                                        amount: event.target.value,
+                                                                                }))
+                                                                        }
+                                                                        placeholder="Enter amount paid"
+                                                                        className="mt-1"
+                                                                />
+                                                        </div>
+                                                        <div>
+                                                                <label className="text-sm font-medium text-gray-700">Notes</label>
+                                                                <Textarea
+                                                                        value={manualUpdateForm.notes}
+                                                                        onChange={(event) =>
+                                                                                setManualUpdateForm((prev) => ({
+                                                                                        ...prev,
+                                                                                        notes: event.target.value,
+                                                                                }))
+                                                                        }
+                                                                        placeholder="Add internal notes for this payout update"
+                                                                        className="mt-1"
+                                                                        rows={4}
+                                                                />
+                                                        </div>
                                                 </div>
-                                        </div>
-                                </CardContent>
-                        </Card>
+
+                                                <DialogFooter>
+                                                        <Button
+                                                                type="button"
+                                                                variant="outline"
+                                                                onClick={() => {
+                                                                        setManualUpdateForm(initialManualUpdateForm);
+                                                                        setIsUpdateDialogOpen(false);
+                                                                }}
+                                                        >
+                                                                Cancel
+                                                        </Button>
+                                                        <Button type="submit" disabled={manualUpdating}>
+                                                                <ClipboardCheck className="mr-2 h-4 w-4" />
+                                                                {manualUpdating ? "Updating..." : "Apply update"}
+                                                        </Button>
+                                                </DialogFooter>
+                                        </form>
+                                </DialogContent>
+                        </Dialog>
                 </div>
         );
 }

--- a/model/Payment.js
+++ b/model/Payment.js
@@ -26,6 +26,45 @@ const PaymentHistorySchema = new mongoose.Schema(
         { _id: false }
 );
 
+const ManualPayoutHistorySchema = new mongoose.Schema(
+        {
+                status: {
+                        type: String,
+                        enum: ["pending", "scheduled", "paid"],
+                        default: "pending",
+                },
+                amount: {
+                        type: Number,
+                        default: 0,
+                },
+                reference: {
+                        type: String,
+                        default: "",
+                        trim: true,
+                },
+                processedAt: {
+                        type: Date,
+                        default: Date.now,
+                },
+                processedBy: {
+                        type: mongoose.Schema.Types.ObjectId,
+                        ref: "User",
+                        default: null,
+                },
+                processedByName: {
+                        type: String,
+                        default: "",
+                        trim: true,
+                },
+                remarks: {
+                        type: String,
+                        default: "",
+                        trim: true,
+                },
+        },
+        { _id: false }
+);
+
 const PaymentSchema = new mongoose.Schema(
         {
                 orderId: {
@@ -105,6 +144,34 @@ const PaymentSchema = new mongoose.Schema(
                         type: [PaymentHistorySchema],
                         default: [],
                 },
+                payoutMode: {
+                        type: String,
+                        enum: ["escrow", "manual"],
+                        default: "escrow",
+                },
+                manualStatus: {
+                        type: String,
+                        enum: ["pending", "scheduled", "paid"],
+                        default: "pending",
+                },
+                manualPaidAt: {
+                        type: Date,
+                        default: null,
+                },
+                manualPayoutReference: {
+                        type: String,
+                        default: null,
+                        trim: true,
+                },
+                manualNotes: {
+                        type: String,
+                        default: "",
+                        trim: true,
+                },
+                manualHistory: {
+                        type: [ManualPayoutHistorySchema],
+                        default: [],
+                },
         },
         { timestamps: true }
 );
@@ -113,6 +180,7 @@ PaymentSchema.index({ sellerId: 1, status: 1 });
 PaymentSchema.index({ orderId: 1 });
 PaymentSchema.index({ subOrderId: 1 });
 PaymentSchema.index({ orderNumber: 1 });
+PaymentSchema.index({ payoutMode: 1, sellerId: 1 });
 
 const PaymentModel =
         mongoose.models.Payment || mongoose.model("Payment", PaymentSchema);

--- a/store/adminManualPayoutStore.js
+++ b/store/adminManualPayoutStore.js
@@ -1,0 +1,210 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+const initialFilters = {
+        status: "all",
+        search: "",
+        startDate: "",
+        endDate: "",
+        page: 1,
+        limit: 10,
+};
+
+export const useAdminManualPayoutStore = create(
+        devtools(
+                persist(
+                        (set, get) => ({
+                                sellers: [],
+                                loading: false,
+                                updating: false,
+                                error: null,
+                                stats: {
+                                        totalSellers: 0,
+                                        pendingAmount: 0,
+                                        scheduledAmount: 0,
+                                        paidAmount: 0,
+                                },
+                                pagination: {
+                                        currentPage: 1,
+                                        totalPages: 1,
+                                        totalRecords: 0,
+                                        hasNext: false,
+                                        hasPrev: false,
+                                },
+                                filters: initialFilters,
+                                selectedSellerIds: [],
+                                setFilters: (filters) =>
+                                        set((state) => ({
+                                                filters: { ...state.filters, ...filters },
+                                        })),
+                                resetFilters: () =>
+                                        set({
+                                                filters: { ...initialFilters },
+                                        }),
+                                fetchSellers: async () => {
+                                        const { filters } = get();
+                                        set({ loading: true, error: null });
+
+                                        try {
+                                                const params = new URLSearchParams();
+
+                                                Object.entries(filters).forEach(([key, value]) => {
+                                                        if (value && value !== "all") {
+                                                                params.append(key, value);
+                                                        }
+                                                });
+
+                                                const response = await fetch(
+                                                        `/api/admin/manual-payouts?${params.toString()}`,
+                                                        {
+                                                                method: "GET",
+                                                                credentials: "include",
+                                                        }
+                                                );
+
+                                                if (!response.ok) {
+                                                        const errorResult = await response.json().catch(() => ({}));
+                                                        throw new Error(
+                                                                errorResult.message || "Failed to fetch manual payouts"
+                                                        );
+                                                }
+
+                                                const data = await response.json();
+
+                                                if (!data.success) {
+                                                        throw new Error(data.message || "Failed to fetch manual payouts");
+                                                }
+
+                                                set({
+                                                        sellers: data.sellers,
+                                                        stats: data.stats,
+                                                        pagination: data.pagination,
+                                                        loading: false,
+                                                });
+                                        } catch (error) {
+                                                set({
+                                                        loading: false,
+                                                        error: error.message || "Failed to fetch manual payouts",
+                                                });
+                                        }
+                                },
+                                toggleSellerSelection: (sellerId, checked) =>
+                                        set((state) => {
+                                                const current = new Set(state.selectedSellerIds);
+
+                                                if (checked === true || (!current.has(sellerId) && checked !== false)) {
+                                                        current.add(sellerId);
+                                                } else {
+                                                        current.delete(sellerId);
+                                                }
+
+                                                return { selectedSellerIds: Array.from(current) };
+                                        }),
+                                selectAllOnPage: () =>
+                                        set((state) => {
+                                                const selected = new Set(state.selectedSellerIds);
+                                                state.sellers.forEach((seller) => {
+                                                        if (seller.sellerId) {
+                                                                selected.add(seller.sellerId);
+                                                        }
+                                                });
+                                                return { selectedSellerIds: Array.from(selected) };
+                                        }),
+                                clearSelection: () => set({ selectedSellerIds: [] }),
+                                downloadCsv: async () => {
+                                        const { filters } = get();
+
+                                        const params = new URLSearchParams();
+                                        Object.entries(filters).forEach(([key, value]) => {
+                                                if (value && value !== "all") {
+                                                        params.append(key, value);
+                                                }
+                                        });
+                                        params.append("export", "csv");
+
+                                        const response = await fetch(
+                                                `/api/admin/manual-payouts?${params.toString()}`,
+                                                {
+                                                        method: "GET",
+                                                        credentials: "include",
+                                                }
+                                        );
+
+                                        if (!response.ok) {
+                                                const errorText = await response.text();
+                                                throw new Error(errorText || "Failed to download manual payouts");
+                                        }
+
+                                        const blob = await response.blob();
+                                        const url = window.URL.createObjectURL(blob);
+                                        const anchor = document.createElement("a");
+                                        anchor.href = url;
+                                        anchor.download = `manual-payouts-${new Date()
+                                                .toISOString()
+                                                .slice(0, 10)}.csv`;
+                                        anchor.style.display = "none";
+                                        document.body.appendChild(anchor);
+                                        anchor.click();
+                                        anchor.remove();
+                                        window.URL.revokeObjectURL(url);
+                                },
+                                bulkUpdateStatus: async ({
+                                        sellerIds,
+                                        status,
+                                        paymentDate,
+                                        reference,
+                                        amount,
+                                        notes,
+                                }) => {
+                                        if (!Array.isArray(sellerIds) || sellerIds.length === 0) {
+                                                throw new Error("Select at least one seller to update");
+                                        }
+
+                                        set({ updating: true });
+                                        try {
+                                                const payload = {
+                                                        updates: sellerIds.map((sellerId) => ({
+                                                                sellerId,
+                                                                status,
+                                                                paymentDate,
+                                                                reference,
+                                                                amount,
+                                                                notes,
+                                                        })),
+                                                };
+
+                                                const response = await fetch("/api/admin/manual-payouts", {
+                                                        method: "PATCH",
+                                                        credentials: "include",
+                                                        headers: {
+                                                                "Content-Type": "application/json",
+                                                        },
+                                                        body: JSON.stringify(payload),
+                                                });
+
+                                                const data = await response.json().catch(() => ({ success: false }));
+
+                                                if (!response.ok || !data.success) {
+                                                        throw new Error(
+                                                                data.message || "Failed to update manual payouts"
+                                                        );
+                                                }
+
+                                                set({ updating: false, selectedSellerIds: [] });
+                                                await get().fetchSellers();
+                                                return data;
+                                        } catch (error) {
+                                                set({ updating: false });
+                                                throw error;
+                                        }
+                                },
+                        }),
+                        {
+                                name: "admin-manual-payout-store",
+                                partialize: (state) => ({
+                                        filters: state.filters,
+                                }),
+                        }
+                )
+        )
+);


### PR DESCRIPTION
## Summary
- extend the payment schema to capture manual payout mode, status tracking, and history entries
- add admin manual payout APIs and Zustand store to aggregate seller balances, export CSV data, and update payouts in bulk
- refresh the admin payments page with escrow/manual tabs, manual payout dashboards, CSV download, and dialog-driven bulk updates

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcaf2cb54832ebe1b33b6804783c1