### PR TITLE
Fix seller account settings infinite render loop

### DIFF
--- a/app/seller/account-settings/page.jsx
+++ b/app/seller/account-settings/page.jsx
@@ -21,12 +21,10 @@ import { useIsSellerAuthenticated } from "@/store/sellerAuthStore";
 export default function AccountSettings() {
         const router = useRouter();
         const isAuthenticated = useIsSellerAuthenticated();
-        const { loading, initialized, error, fetchCompany } = useSellerCompanyStore((state) => ({
-                loading: state.loading,
-                initialized: state.initialized,
-                error: state.error,
-                fetchCompany: state.fetchCompany,
-        }));
+        const loading = useSellerCompanyStore((state) => state.loading);
+        const initialized = useSellerCompanyStore((state) => state.initialized);
+        const error = useSellerCompanyStore((state) => state.error);
+        const fetchCompany = useSellerCompanyStore((state) => state.fetchCompany);
 
         useEffect(() => {
                 if (!isAuthenticated) {

--- a/components/SellerPanel/Settings/address.jsx
+++ b/components/SellerPanel/Settings/address.jsx
@@ -27,21 +27,12 @@ const EMPTY_DRAFT = {
 };
 
 export default function CompanyAddresses() {
-        const {
-                company,
-                loading,
-                initialized,
-                addressesSaving,
-                fetchCompany,
-                updateAddresses,
-        } = useSellerCompanyStore((state) => ({
-                company: state.company,
-                loading: state.loading,
-                initialized: state.initialized,
-                addressesSaving: state.addressesSaving,
-                fetchCompany: state.fetchCompany,
-                updateAddresses: state.updateAddresses,
-        }));
+        const company = useSellerCompanyStore((state) => state.company);
+        const loading = useSellerCompanyStore((state) => state.loading);
+        const initialized = useSellerCompanyStore((state) => state.initialized);
+        const addressesSaving = useSellerCompanyStore((state) => state.addressesSaving);
+        const fetchCompany = useSellerCompanyStore((state) => state.fetchCompany);
+        const updateAddresses = useSellerCompanyStore((state) => state.updateAddresses);
 
         const [addresses, setAddresses] = useState([]);
         const [editingIndex, setEditingIndex] = useState(-1);

--- a/components/SellerPanel/Settings/bank-details.jsx
+++ b/components/SellerPanel/Settings/bank-details.jsx
@@ -76,21 +76,12 @@ const getAccountTypeLabel = (value) => {
 };
 
 export default function BankDetailsCard() {
-        const {
-                company,
-                loading,
-                initialized,
-                bankSaving,
-                fetchCompany,
-                updateBankDetails,
-        } = useSellerCompanyStore((state) => ({
-                company: state.company,
-                loading: state.loading,
-                initialized: state.initialized,
-                bankSaving: state.bankSaving,
-                fetchCompany: state.fetchCompany,
-                updateBankDetails: state.updateBankDetails,
-        }));
+        const company = useSellerCompanyStore((state) => state.company);
+        const loading = useSellerCompanyStore((state) => state.loading);
+        const initialized = useSellerCompanyStore((state) => state.initialized);
+        const bankSaving = useSellerCompanyStore((state) => state.bankSaving);
+        const fetchCompany = useSellerCompanyStore((state) => state.fetchCompany);
+        const updateBankDetails = useSellerCompanyStore((state) => state.updateBankDetails);
 
         const [isEditing, setIsEditing] = useState(false);
         const [form, setForm] = useState(EMPTY_FORM);

--- a/components/SellerPanel/Settings/form.jsx
+++ b/components/SellerPanel/Settings/form.jsx
@@ -26,27 +26,15 @@ const EMPTY_FORM = {
 };
 
 export default function ShopForm() {
-        const {
-                company,
-                loading,
-                initialized,
-                saving,
-                uploadingLogo,
-                fetchCompany,
-                saveCompany,
-                uploadLogo,
-                setCompany,
-        } = useSellerCompanyStore((state) => ({
-                company: state.company,
-                loading: state.loading,
-                initialized: state.initialized,
-                saving: state.saving,
-                uploadingLogo: state.uploadingLogo,
-                fetchCompany: state.fetchCompany,
-                saveCompany: state.saveCompany,
-                uploadLogo: state.uploadLogo,
-                setCompany: state.setCompany,
-        }));
+        const company = useSellerCompanyStore((state) => state.company);
+        const loading = useSellerCompanyStore((state) => state.loading);
+        const initialized = useSellerCompanyStore((state) => state.initialized);
+        const saving = useSellerCompanyStore((state) => state.saving);
+        const uploadingLogo = useSellerCompanyStore((state) => state.uploadingLogo);
+        const fetchCompany = useSellerCompanyStore((state) => state.fetchCompany);
+        const saveCompany = useSellerCompanyStore((state) => state.saveCompany);
+        const uploadLogo = useSellerCompanyStore((state) => state.uploadLogo);
+        const setCompany = useSellerCompanyStore((state) => state.setCompany);
 
         const [form, setForm] = useState(EMPTY_FORM);
 


### PR DESCRIPTION
## Summary
- subscribe to individual slices from the seller company store in the account settings page to avoid unstable snapshots
- update seller account settings forms, address, and bank detail cards to rely on the same stable selectors

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcb821318832ea2d753d2c10a28f6