### PR TITLE
Handle missing product data on seller orders page

### DIFF
--- a/app/seller/orders/page.jsx
+++ b/app/seller/orders/page.jsx
@@ -374,7 +374,13 @@ function SellerOrdersPage() {
 											</TableCell>
 											<TableCell>
 												<div className="space-y-2">
-													{order.products.slice(0, 2).map((product, index) => (
+                                                                        {(
+                                                                                Array.isArray(order.products)
+                                                                                        ? order.products
+                                                                                        : []
+                                                                        )
+                                                                                .slice(0, 2)
+                                                                                .map((product, index) => (
 														<div
 															key={index}
 															className="flex items-center gap-3"
@@ -397,7 +403,7 @@ function SellerOrdersPage() {
 															</div>
 														</div>
 													))}
-													{order.products.length > 2 && (
+                                        {Array.isArray(order.products) && order.products.length > 2 && (
 														<p className="text-xs text-gray-500">
 															+{order.products.length - 2} more items
 														</p>
@@ -410,7 +416,11 @@ function SellerOrdersPage() {
 												</Badge>
 											</TableCell>
 											<TableCell className="font-medium text-green-600">
-												₹{order.totalAmount.toFixed(2)}
+                                                                                                ₹{Number(
+                                                                                                        order.totalAmount ??
+                                                                                                                order.orderId?.totalAmount ??
+                                                                                                                0
+                                                                                                ).toFixed(2)}
 											</TableCell>
 											<TableCell>
 												<Badge className={getStatusColor(order.status)}>


### PR DESCRIPTION
## Summary
- guard the seller orders table against orders that do not include a products array
- ensure the displayed total amount falls back to known numeric values before formatting

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dce7cfe420832e9fa1cc95acc07221