### PR TITLE
Handle cancellation notifications across channels

### DIFF
--- a/lib/orders/email.js
+++ b/lib/orders/email.js
@@ -374,8 +374,125 @@ export async function sendOrderFailureEmail({ order, to, cc, failureReason } = {
         return { emailSent: true };
 }
 
+export async function sendOrderCancellationEmail({
+        order,
+        subOrder,
+        to,
+        cc,
+        cancelledBy,
+        reason,
+} = {}) {
+        const normalizedOrder = normalizeOrderForEmail(order);
+
+        const recipients = Array.isArray(to)
+                ? to.filter(Boolean)
+                : to
+                ? [to]
+                : [];
+
+        if (recipients.length === 0 && normalizedOrder.customerEmail) {
+                recipients.push(normalizedOrder.customerEmail);
+        }
+
+        if (recipients.length === 0) {
+                throw new Error("No recipient email address available for cancellation notice");
+        }
+
+        const cancellationActor =
+                cancelledBy === "seller"
+                        ? "the seller"
+                        : cancelledBy === "admin"
+                          ? "our support team"
+                          : "our team";
+
+        const plainSubOrder =
+                subOrder && typeof subOrder.toObject === "function"
+                        ? subOrder.toObject()
+                        : subOrder || null;
+
+        const sellerName =
+                plainSubOrder?.sellerId?.businessName ||
+                plainSubOrder?.sellerId?.name ||
+                null;
+
+        const cancelledSection = plainSubOrder
+                ? `the shipment handled by ${
+                          sellerName ? `<strong>${sellerName}</strong>` : "one of your sellers"
+                  }`
+                : "your order";
+
+        const cancelledProducts = Array.isArray(plainSubOrder?.products)
+                ? plainSubOrder.products.map((item) => ({
+                          productName:
+                                  item.productName ||
+                                  item.productId?.title ||
+                                  item.productId?.name ||
+                                  "Product",
+                          quantity: item.quantity || 0,
+                          totalPrice: Number(
+                                  item.totalPrice ??
+                                          (Number.isFinite(Number(item.price))
+                                                  ? Number(item.price) * Number(item.quantity || 0)
+                                                  : 0)
+                          ),
+                  }))
+                : normalizedOrder.products;
+
+        const productsHtml = buildOrderItemsHtml(cancelledProducts);
+
+        const reasonHtml = reason
+                ? `<p style="margin-top:16px;"><strong>Reason provided:</strong> ${reason}</p>`
+                : "";
+
+        const orderStatusMessage =
+                order?.status === "cancelled"
+                        ? "The entire order has been cancelled and any pending payments will be reversed as per our policy."
+                        : "The remaining items in your order will continue to be processed normally.";
+
+        const html = `
+                <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333;">
+                        <h2 style="color:#dc2626;">Update on your order</h2>
+                        <p>Hi ${normalizedOrder.customerName || "Customer"},</p>
+                        <p>We wanted to let you know that ${cancelledSection} for order <strong>${
+                                normalizedOrder.orderNumber || ""
+                        }</strong> was cancelled by ${cancellationActor}.</p>
+                        ${reasonHtml}
+                        <p style="margin-top:16px;">The following items are affected:</p>
+                        <table style="width:100%;border-collapse:collapse;">
+                                <thead>
+                                        <tr style="background:#f3f4f6;">
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Product</th>
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Qty</th>
+                                                <th style="padding:8px;border:1px solid #e5e7eb;text-align:right;">Total</th>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        ${productsHtml}
+                                </tbody>
+                        </table>
+                        <p style="margin-top:16px;">${orderStatusMessage}</p>
+                        <p>If you have any questions or need support, reply to this email or reach us at ${
+                                companyInfo.email
+                        }.</p>
+                        <p style="margin-top:16px;">Best regards,<br/>${
+                                companyInfo.name || companyInfo.companyName || "Team"
+                        }</p>
+                </div>
+        `;
+
+        await sendMail({
+                to: recipients,
+                cc,
+                subject: `Order Update - ${normalizedOrder.orderNumber || "Shipment Cancelled"}`,
+                html,
+        });
+
+        return { emailSent: true };
+}
+
 export default {
         normalizeOrderForEmail,
         sendOrderConfirmationEmail,
         sendOrderFailureEmail,
+        sendOrderCancellationEmail,
 };


### PR DESCRIPTION
## Summary
- add a shared order cancellation email to notify customers and admins about shipment cancellations
- update the seller cancellation endpoint to sync parent order status changes and trigger notifications
- ensure admin order updates propagate cancellation to all sub-orders and email stakeholders

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser due to project lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dcea059b40832e9ec63cb5cd93697f