### PR TITLE
feat: fetch notifications dynamically for admin and seller panels

### DIFF
--- a/app/admin/notifications/page.jsx
+++ b/app/admin/notifications/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
         AlertTriangle,
@@ -128,11 +128,21 @@ export default function AdminNotificationsPage() {
         const markAllAsRead = useNotificationStore((state) => state.markAllAsRead);
         const markPanelAsRead = useNotificationStore((state) => state.markPanelAsRead);
         const unreadCounts = useNotificationStore((state) => state.unreadCounts);
+        const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+        const loading = useNotificationStore((state) => state.loading);
+        const error = useNotificationStore((state) => state.error);
+        const hasHydrated = useNotificationStore((state) => state.hasHydrated);
 
         const [activePanel, setActivePanel] = useState("all");
         const [activeSeverity, setActiveSeverity] = useState("all");
         const [searchTerm, setSearchTerm] = useState("");
         const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+
+        useEffect(() => {
+                fetchNotifications();
+        }, [fetchNotifications]);
+
+        const isLoading = !hasHydrated || loading;
 
         const filteredNotifications = useMemo(() => {
                 return notifications.filter((notification) => {
@@ -179,6 +189,11 @@ export default function AdminNotificationsPage() {
 
         return (
                 <div className="space-y-6">
+                        {error && (
+                                <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                                        Unable to load some notifications. Please refresh to try again.
+                                </div>
+                        )}
                         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                                 <div>
                                         <h1 className="text-2xl font-semibold tracking-tight">Notification center</h1>
@@ -217,10 +232,19 @@ export default function AdminNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent>
-                                                <p className="text-2xl font-semibold">{notifications.length}</p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        {todaysNotifications.length} new today
-                                                </p>
+                                                {isLoading && notifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-16 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">{notifications.length}</p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        {todaysNotifications.length} new today
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -230,14 +254,23 @@ export default function AdminNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent className="space-y-1">
-                                                <p className="text-2xl font-semibold">{totalUnread}</p>
-                                                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                                                        <span>{unreadCounts.seller} seller</span>
-                                                        <span className="text-muted-foreground/60">•</span>
-                                                        <span>{unreadCounts.buyer} buyer</span>
-                                                        <span className="text-muted-foreground/60">•</span>
-                                                        <span>{unreadCounts.admin} admin</span>
-                                                </div>
+                                                {isLoading && notifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-16 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">{totalUnread}</p>
+                                                                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                                                        <span>{unreadCounts.seller} seller</span>
+                                                                        <span className="text-muted-foreground/60">•</span>
+                                                                        <span>{unreadCounts.buyer} buyer</span>
+                                                                        <span className="text-muted-foreground/60">•</span>
+                                                                        <span>{unreadCounts.admin} admin</span>
+                                                                </div>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -247,18 +280,27 @@ export default function AdminNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent>
-                                                <p className="text-2xl font-semibold">
-                                                        {
-                                                                notifications.filter((notification) =>
-                                                                        ["warning", "critical"].includes(
-                                                                                notification.severity
-                                                                        ) && !notification.read
-                                                                ).length
-                                                        }
-                                                </p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        Pending escalations requiring review
-                                                </p>
+                                                {isLoading && notifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-16 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">
+                                                                        {
+                                                                                notifications.filter((notification) =>
+                                                                                        ["warning", "critical"].includes(
+                                                                                                notification.severity
+                                                                                        ) && !notification.read
+                                                                                ).length
+                                                                        }
+                                                                </p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        Pending escalations requiring review
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -268,16 +310,25 @@ export default function AdminNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent className="space-y-1">
-                                                <p className="text-2xl font-semibold">
-                                                        {formatRelativeTime(
-                                                                useNotificationStore.getState().lastViewedAt ||
-                                                                        notifications[0]?.createdAt ||
-                                                                        new Date().toISOString()
-                                                        )}
-                                                </p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        Keeping audit trail fresh
-                                                </p>
+                                                {isLoading && notifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-20 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-28 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">
+                                                                        {formatRelativeTime(
+                                                                                useNotificationStore.getState().lastViewedAt ||
+                                                                                        notifications[0]?.createdAt ||
+                                                                                        new Date().toISOString()
+                                                                        )}
+                                                                </p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        Keeping audit trail fresh
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                         </div>
@@ -333,7 +384,33 @@ export default function AdminNotificationsPage() {
                                 </CardHeader>
                                 <CardContent className="p-0">
                                         <ScrollArea className="max-h-[62vh]">
-                                                {filteredNotifications.length === 0 ? (
+                                                {isLoading && notifications.length === 0 ? (
+                                                        <div className="space-y-6 px-6 py-6">
+                                                                {[...Array(3)].map((_, index) => (
+                                                                        <div key={index} className="space-y-4">
+                                                                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                                                                        <div className="h-3 w-24 animate-pulse rounded-full bg-muted" />
+                                                                                </div>
+                                                                                <div className="space-y-3">
+                                                                                        {[...Array(2)].map((__, itemIndex) => (
+                                                                                                <div
+                                                                                                        key={itemIndex}
+                                                                                                        className="flex gap-3 rounded-lg border p-4"
+                                                                                                >
+                                                                                                        <div className="h-9 w-9 animate-pulse rounded-full bg-muted" />
+                                                                                                        <div className="flex-1 space-y-2">
+                                                                                                                <div className="h-4 w-1/3 animate-pulse rounded bg-muted" />
+                                                                                                                <div className="h-3 w-full animate-pulse rounded bg-muted" />
+                                                                                                                <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+                                                                                                        </div>
+                                                                                                        <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+                                                                                                </div>
+                                                                                        ))}
+                                                                                </div>
+                                                                        </div>
+                                                                ))}
+                                                        </div>
+                                                ) : filteredNotifications.length === 0 ? (
                                                         <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
                                                                 <Inbox className="mb-3 h-10 w-10" />
                                                                 <p className="font-medium">No notifications match the current filters.</p>

--- a/app/api/notifications/[id]/route.js
+++ b/app/api/notifications/[id]/route.js
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import Notification from "@/model/Notification";
+
+const normalizeMetadata = (metadata) => {
+        if (!metadata) return undefined;
+
+        if (Array.isArray(metadata)) {
+                const normalized = metadata
+                        .filter((item) => item && typeof item === "object")
+                        .map((item) => ({
+                                label: String(item.label ?? "").trim(),
+                                value: String(item.value ?? "").trim(),
+                        }))
+                        .filter((item) => item.label && item.value);
+
+                return normalized.length ? normalized : [];
+        }
+
+        if (typeof metadata === "object") {
+                const normalized = Object.entries(metadata)
+                        .filter(([, value]) => value !== undefined && value !== null)
+                        .map(([label, value]) => ({
+                                label: label
+                                        .replace(/([A-Z])/g, " $1")
+                                        .replace(/^./, (str) => str.toUpperCase()),
+                                value: String(value).trim(),
+                        }));
+
+                return normalized.length ? normalized : [];
+        }
+
+        if (metadata === null) {
+                return [];
+        }
+
+        return undefined;
+};
+
+export async function PATCH(request, { params }) {
+        const { id } = params;
+        const payload = await request.json();
+
+        await dbConnect();
+
+        const update = {};
+
+        if (payload.title !== undefined) update.title = payload.title;
+        if (payload.message !== undefined) update.message = payload.message;
+        if (payload.panel !== undefined) update.panel = payload.panel;
+        if (payload.category !== undefined) update.category = payload.category;
+        if (payload.severity !== undefined) update.severity = payload.severity;
+
+        const normalizedMetadata = normalizeMetadata(payload.metadata);
+        if (normalizedMetadata !== undefined) {
+                update.metadata = normalizedMetadata;
+        }
+
+        if (payload.actor !== undefined) {
+                update.actor = payload.actor
+                        ? {
+                                  name: payload.actor.name || "",
+                                  role: payload.actor.role || "",
+                          }
+                        : null;
+        }
+
+        if (payload.link !== undefined) {
+                update.link = payload.link
+                        ? {
+                                  href: payload.link.href || "",
+                                  label: payload.link.label || "View details",
+                          }
+                        : null;
+        }
+
+        if (payload.status !== undefined) {
+                update.status = payload.status;
+        }
+
+        if (payload.read !== undefined) {
+                update.read = Boolean(payload.read);
+                update.readAt = update.read
+                        ? payload.readAt
+                                ? new Date(payload.readAt)
+                                : new Date()
+                        : null;
+        }
+
+        update.updatedAt = new Date();
+
+        try {
+                const notification = await Notification.findByIdAndUpdate(id, update, {
+                        new: true,
+                        runValidators: true,
+                }).lean();
+
+                if (!notification) {
+                        return NextResponse.json(
+                                { message: "Notification not found" },
+                                { status: 404 }
+                        );
+                }
+
+                return NextResponse.json({ notification });
+        } catch (error) {
+                console.error(`Failed to update notification ${id}`, error);
+                return NextResponse.json(
+                        { message: "Failed to update notification" },
+                        { status: 500 }
+                );
+        }
+}
+
+export async function DELETE(request, { params }) {
+        const { id } = params;
+
+        await dbConnect();
+
+        try {
+                const notification = await Notification.findByIdAndDelete(id).lean();
+
+                if (!notification) {
+                        return NextResponse.json(
+                                { message: "Notification not found" },
+                                { status: 404 }
+                        );
+                }
+
+                return NextResponse.json({ success: true });
+        } catch (error) {
+                console.error(`Failed to delete notification ${id}`, error);
+                return NextResponse.json(
+                        { message: "Failed to delete notification" },
+                        { status: 500 }
+                );
+        }
+}

--- a/app/api/notifications/route.js
+++ b/app/api/notifications/route.js
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import Notification from "@/model/Notification";
+
+const normalizeMetadata = (metadata) => {
+        if (!metadata) return [];
+
+        if (Array.isArray(metadata)) {
+                return metadata
+                        .filter((item) => item && typeof item === "object")
+                        .map((item) => ({
+                                label: String(item.label ?? "").trim(),
+                                value: String(item.value ?? "").trim(),
+                        }))
+                        .filter((item) => item.label && item.value);
+        }
+
+        if (typeof metadata === "object") {
+                return Object.entries(metadata)
+                        .filter(([, value]) => value !== undefined && value !== null)
+                        .map(([label, value]) => ({
+                                label: label
+                                        .replace(/([A-Z])/g, " $1")
+                                        .replace(/^./, (str) => str.toUpperCase()),
+                                value: String(value).trim(),
+                        }));
+        }
+
+        return [];
+};
+
+const sanitizePayload = (payload) => ({
+        panel: payload.panel === "all" ? "all" : payload.panel || "admin",
+        category: payload.category || "general",
+        title: payload.title || "New activity",
+        message: payload.message || "",
+        severity: payload.severity || "info",
+        metadata: normalizeMetadata(payload.metadata),
+        actor: payload.actor
+                ? {
+                          name: payload.actor.name || "",
+                          role: payload.actor.role || "",
+                  }
+                : null,
+        link: payload.link
+                ? {
+                          href: payload.link.href || "",
+                          label: payload.link.label || "View details",
+                  }
+                : null,
+        status: payload.status || "open",
+        read: Boolean(payload.read),
+        readAt: payload.read
+                ? payload.readAt
+                        ? new Date(payload.readAt)
+                        : new Date()
+                : null,
+});
+
+export async function GET(request) {
+        const { searchParams } = new URL(request.url);
+        const panel = searchParams.get("panel");
+        const unreadOnly = searchParams.get("unreadOnly");
+        const limit = Number.parseInt(searchParams.get("limit") || "0", 10);
+        const status = searchParams.get("status");
+
+        await dbConnect();
+
+        const query = {};
+
+        if (panel && panel !== "all") {
+                query.panel = panel;
+        }
+
+        if (status) {
+                query.status = status;
+        }
+
+        if (unreadOnly === "true") {
+                query.read = false;
+        }
+
+        const notificationsQuery = Notification.find(query).sort({ createdAt: -1 });
+
+        if (limit > 0) {
+                notificationsQuery.limit(limit);
+        }
+
+        const notifications = await notificationsQuery.lean();
+
+        return NextResponse.json({ notifications });
+}
+
+export async function POST(request) {
+        const payload = await request.json();
+        const clientId = payload.clientId || null;
+
+        await dbConnect();
+
+        const sanitized = sanitizePayload(payload);
+
+        try {
+                const notification = await Notification.create(sanitized);
+                return NextResponse.json(
+                        {
+                                notification,
+                                clientId,
+                        },
+                        { status: 201 }
+                );
+        } catch (error) {
+                console.error("Notification creation error", error);
+                return NextResponse.json(
+                        {
+                                message: "Failed to create notification",
+                        },
+                        { status: 500 }
+                );
+        }
+}

--- a/app/seller/notifications/page.jsx
+++ b/app/seller/notifications/page.jsx
@@ -90,6 +90,10 @@ export default function SellerNotificationsPage() {
         const dismissNotification = useNotificationStore((state) => state.dismissNotification);
         const markPanelAsRead = useNotificationStore((state) => state.markPanelAsRead);
         const unreadCount = useUnreadNotifications("seller");
+        const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+        const loading = useNotificationStore((state) => state.loading);
+        const error = useNotificationStore((state) => state.error);
+        const hasHydrated = useNotificationStore((state) => state.hasHydrated);
 
         useEffect(() => {
                 if (!isAuthenticated) {
@@ -97,10 +101,18 @@ export default function SellerNotificationsPage() {
                 }
         }, [isAuthenticated, router]);
 
+        useEffect(() => {
+                if (isAuthenticated) {
+                        fetchNotifications();
+                }
+        }, [fetchNotifications, isAuthenticated]);
+
         const [searchTerm, setSearchTerm] = useState("");
         const [activeSeverity, setActiveSeverity] = useState("all");
         const [showUnreadOnly, setShowUnreadOnly] = useState(false);
         const [activeCategory, setActiveCategory] = useState("all");
+
+        const isLoading = !hasHydrated || loading;
 
         const sellerNotifications = useMemo(
                 () =>
@@ -192,6 +204,11 @@ export default function SellerNotificationsPage() {
 
         return (
                 <div className="space-y-6 p-6">
+                        {error && (
+                                <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                                        We couldn't refresh notifications. Please try again later.
+                                </div>
+                        )}
                         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                                 <div>
                                         <h1 className="text-2xl font-semibold tracking-tight">Seller notifications</h1>
@@ -225,10 +242,19 @@ export default function SellerNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent>
-                                                <p className="text-2xl font-semibold">{sellerNotifications.length}</p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        {todaysNotifications.length} new today
-                                                </p>
+                                                {isLoading && sellerNotifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-16 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">{sellerNotifications.length}</p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        {todaysNotifications.length} new today
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -238,10 +264,19 @@ export default function SellerNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent className="space-y-1">
-                                                <p className="text-2xl font-semibold">{unreadCount}</p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        Stay up to date by reviewing new activity promptly.
-                                                </p>
+                                                {isLoading && sellerNotifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-14 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-36 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">{unreadCount}</p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        Stay up to date by reviewing new activity promptly.
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -251,10 +286,19 @@ export default function SellerNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent>
-                                                <p className="text-2xl font-semibold">{criticalAttention}</p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        Pending warnings or escalations requiring action.
-                                                </p>
+                                                {isLoading && sellerNotifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-14 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-44 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">{criticalAttention}</p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        Pending warnings or escalations requiring action.
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                                 <Card>
@@ -264,14 +308,23 @@ export default function SellerNotificationsPage() {
                                                 </CardTitle>
                                         </CardHeader>
                                         <CardContent className="space-y-1">
-                                                <p className="text-2xl font-semibold">
-                                                        {sellerNotifications[0]
-                                                                ? formatRelativeTime(sellerNotifications[0].createdAt)
-                                                                : "Just now"}
-                                                </p>
-                                                <p className="text-xs text-muted-foreground">
-                                                        Notifications update automatically as events occur.
-                                                </p>
+                                                {isLoading && sellerNotifications.length === 0 ? (
+                                                        <div className="space-y-2">
+                                                                <div className="h-6 w-20 animate-pulse rounded bg-muted" />
+                                                                <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+                                                        </div>
+                                                ) : (
+                                                        <>
+                                                                <p className="text-2xl font-semibold">
+                                                                        {sellerNotifications[0]
+                                                                                ? formatRelativeTime(sellerNotifications[0].createdAt)
+                                                                                : "Just now"}
+                                                                </p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        Notifications update automatically as events occur.
+                                                                </p>
+                                                        </>
+                                                )}
                                         </CardContent>
                                 </Card>
                         </div>
@@ -334,7 +387,38 @@ export default function SellerNotificationsPage() {
                                 <CardContent className="p-0">
                                         <ScrollArea className="max-h-[60vh]">
                                                 <div className="divide-y">
-                                                        {groupedNotifications.length === 0 ? (
+                                                        {isLoading && sellerNotifications.length === 0 ? (
+                                                                <div className="space-y-6 p-6">
+                                                                        {[...Array(3)].map((_, index) => (
+                                                                                <div key={index} className="space-y-4">
+                                                                                        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                                                                <div className="h-3 w-24 animate-pulse rounded-full bg-muted" />
+                                                                                        </div>
+                                                                                        <div className="space-y-4">
+                                                                                                {[...Array(2)].map((__, itemIndex) => (
+                                                                                                        <div
+                                                                                                                key={itemIndex}
+                                                                                                                className="rounded-lg border bg-background p-4"
+                                                                                                        >
+                                                                                                                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                                                                                                                        <div className="space-y-2">
+                                                                                                                                <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                                                                                                                                <div className="h-3 w-full animate-pulse rounded bg-muted" />
+                                                                                                                                <div className="h-3 w-3/4 animate-pulse rounded bg-muted" />
+                                                                                                                        </div>
+                                                                                                                        <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+                                                                                                                </div>
+                                                                                                                <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-sm">
+                                                                                                                        <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+                                                                                                                        <div className="h-8 w-20 animate-pulse rounded bg-muted" />
+                                                                                                                </div>
+                                                                                                        </div>
+                                                                                                ))}
+                                                                                        </div>
+                                                                                </div>
+                                                                        ))}
+                                                                </div>
+                                                        ) : groupedNotifications.length === 0 ? (
                                                                 <div className="flex flex-col items-center justify-center gap-2 py-16 text-center text-muted-foreground">
                                                                         <Inbox className="h-6 w-6" />
                                                                         <p className="text-sm">No notifications match your filters yet.</p>

--- a/components/AdminPanel/NotificationDropdown.jsx
+++ b/components/AdminPanel/NotificationDropdown.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Bell, CheckCheck, ArrowUpRight, Archive, EyeOff } from "lucide-react";
@@ -66,7 +66,15 @@ export function NotificationDropdown() {
         const markAsRead = useNotificationStore((state) => state.markAsRead);
         const markAllAsRead = useNotificationStore((state) => state.markAllAsRead);
         const dismissNotification = useNotificationStore((state) => state.dismissNotification);
+        const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+        const loading = useNotificationStore((state) => state.loading);
+        const error = useNotificationStore((state) => state.error);
+        const hasHydrated = useNotificationStore((state) => state.hasHydrated);
         const unreadCount = useUnreadNotifications();
+
+        useEffect(() => {
+                fetchNotifications();
+        }, [fetchNotifications]);
 
         const recentNotifications = useMemo(
                 () => notifications.slice(0, 6),
@@ -79,6 +87,8 @@ export function NotificationDropdown() {
                         router.push(notification.link.href);
                 }
         };
+
+        const isLoading = !hasHydrated || loading;
 
         return (
                 <DropdownMenu>
@@ -118,9 +128,25 @@ export function NotificationDropdown() {
                                 </div>
                                 <ScrollArea className="max-h-96">
                                         <div className="divide-y">
-                                                {recentNotifications.length === 0 ? (
+                                                {error ? (
+                                                        <div className="px-4 py-8 text-sm text-destructive">
+                                                                Unable to load notifications. Please try again shortly.
+                                                        </div>
+                                                ) : isLoading && recentNotifications.length === 0 ? (
+                                                        <div className="flex flex-col gap-3 px-4 py-6">
+                                                                <div className="h-3 w-32 animate-pulse rounded-full bg-muted" />
+                                                                <div className="space-y-2">
+                                                                        <div className="h-3 w-full animate-pulse rounded-full bg-muted" />
+                                                                        <div className="h-3 w-3/4 animate-pulse rounded-full bg-muted" />
+                                                                </div>
+                                                                <div className="space-y-2">
+                                                                        <div className="h-3 w-full animate-pulse rounded-full bg-muted" />
+                                                                        <div className="h-3 w-2/3 animate-pulse rounded-full bg-muted" />
+                                                                </div>
+                                                        </div>
+                                                ) : recentNotifications.length === 0 ? (
                                                         <div className="flex flex-col items-center justify-center py-10 text-center text-muted-foreground">
-                                                                <EyeOff className="h-10 w-10 mb-2" />
+                                                                <EyeOff className="mb-2 h-10 w-10" />
                                                                 <p className="font-medium">You're all caught up</p>
                                                                 <p className="text-sm">
                                                                         New notifications will appear here from all panels.

--- a/components/SellerPanel/Layout/NotificationDropdown.jsx
+++ b/components/SellerPanel/Layout/NotificationDropdown.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
@@ -52,7 +52,15 @@ export function NotificationDropdown() {
         const markAsRead = useNotificationStore((state) => state.markAsRead);
         const markPanelAsRead = useNotificationStore((state) => state.markPanelAsRead);
         const dismissNotification = useNotificationStore((state) => state.dismissNotification);
+        const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+        const loading = useNotificationStore((state) => state.loading);
+        const error = useNotificationStore((state) => state.error);
+        const hasHydrated = useNotificationStore((state) => state.hasHydrated);
         const unreadCount = useUnreadNotifications("seller");
+
+        useEffect(() => {
+                fetchNotifications();
+        }, [fetchNotifications]);
 
         const sellerNotifications = useMemo(
                 () =>
@@ -71,6 +79,8 @@ export function NotificationDropdown() {
         const handleOpenCenter = () => {
                 router.push("/seller/notifications");
         };
+
+        const isLoading = !hasHydrated || loading;
 
         return (
                 <DropdownMenu>
@@ -108,7 +118,23 @@ export function NotificationDropdown() {
                                 </div>
                                 <ScrollArea className="max-h-96">
                                         <div className="divide-y">
-                                                {recentNotifications.length === 0 ? (
+                                                {error ? (
+                                                        <div className="px-4 py-8 text-sm text-destructive">
+                                                                Unable to load notifications. Try refreshing the page.
+                                                        </div>
+                                                ) : isLoading && recentNotifications.length === 0 ? (
+                                                        <div className="flex flex-col gap-3 px-4 py-6">
+                                                                <div className="h-3 w-32 animate-pulse rounded-full bg-muted" />
+                                                                <div className="space-y-2">
+                                                                        <div className="h-3 w-full animate-pulse rounded-full bg-muted" />
+                                                                        <div className="h-3 w-4/5 animate-pulse rounded-full bg-muted" />
+                                                                </div>
+                                                                <div className="space-y-2">
+                                                                        <div className="h-3 w-full animate-pulse rounded-full bg-muted" />
+                                                                        <div className="h-3 w-2/3 animate-pulse rounded-full bg-muted" />
+                                                                </div>
+                                                        </div>
+                                                ) : recentNotifications.length === 0 ? (
                                                         <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
                                                                 <Bell className="mb-2 h-6 w-6 text-muted-foreground" />
                                                                 <p>No notifications yet</p>

--- a/model/Notification.js
+++ b/model/Notification.js
@@ -1,0 +1,62 @@
+import mongoose from "mongoose";
+
+const MetadataSchema = new mongoose.Schema(
+        {
+                label: { type: String, trim: true, required: true },
+                value: { type: String, trim: true, required: true },
+        },
+        { _id: false }
+);
+
+const ActorSchema = new mongoose.Schema(
+        {
+                name: { type: String, trim: true },
+                role: { type: String, trim: true },
+        },
+        { _id: false }
+);
+
+const LinkSchema = new mongoose.Schema(
+        {
+                href: { type: String, trim: true },
+                label: { type: String, trim: true },
+        },
+        { _id: false }
+);
+
+const NotificationSchema = new mongoose.Schema(
+        {
+                panel: {
+                        type: String,
+                        enum: ["admin", "seller", "buyer", "all"],
+                        default: "admin",
+                },
+                category: { type: String, trim: true, default: "general" },
+                title: { type: String, required: true, trim: true },
+                message: { type: String, trim: true, default: "" },
+                severity: {
+                        type: String,
+                        enum: ["info", "success", "warning", "critical"],
+                        default: "info",
+                },
+                metadata: { type: [MetadataSchema], default: [] },
+                actor: { type: ActorSchema, default: null },
+                link: { type: LinkSchema, default: null },
+                status: {
+                        type: String,
+                        enum: ["open", "acknowledged", "resolved", "archived"],
+                        default: "open",
+                },
+                read: { type: Boolean, default: false },
+                readAt: { type: Date, default: null },
+        },
+        {
+                timestamps: true,
+        }
+);
+
+NotificationSchema.index({ panel: 1, createdAt: -1 });
+NotificationSchema.index({ read: 1, panel: 1 });
+
+export default mongoose.models.Notification ||
+        mongoose.model("Notification", NotificationSchema);


### PR DESCRIPTION
## Summary
- add a Mongo-backed notification model and REST API so panels can request live data
- hydrate the notification store from the API and sync read/archive actions back to the server
- refresh admin and seller notification UIs to auto-fetch data and display loading/error states

## Testing
- npm run lint *(fails: "Cannot serialize key \"parse\" in parser")*

------
https://chatgpt.com/codex/tasks/task_e_68dcf3e98b7c832eb2a04f20c59c330e