### PR TITLE
Fix notifications API dbConnect import usage

### DIFF
--- a/app/api/notifications/[id]/route.js
+++ b/app/api/notifications/[id]/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import dbConnect from "@/lib/dbConnect";
+import { dbConnect } from "@/lib/dbConnect";
 import Notification from "@/model/Notification";
 
 const normalizeMetadata = (metadata) => {

--- a/app/api/notifications/route.js
+++ b/app/api/notifications/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import dbConnect from "@/lib/dbConnect";
+import { dbConnect } from "@/lib/dbConnect";
 import Notification from "@/model/Notification";
 
 const normalizeMetadata = (metadata) => {


### PR DESCRIPTION
## Summary
- switch the notifications API routes to use the named dbConnect export
