### PR TITLE
Fix admin approval enum on Payment model

### DIFF
--- a/app/api/admin/payments/[id]/approve/route.js
+++ b/app/api/admin/payments/[id]/approve/route.js
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import jwt from "jsonwebtoken";
+
+import { dbConnect } from "@/lib/dbConnect.js";
+import { approveEscrowPayment } from "@/lib/payments/releaseEscrowPayment.js";
+
+export async function POST(request, { params }) {
+        try {
+                await dbConnect();
+
+                const token = request.cookies.get("admin_token")?.value;
+
+                if (!token) {
+                        return NextResponse.json(
+                                { success: false, message: "Unauthorized" },
+                                { status: 401 }
+                        );
+                }
+
+                const decoded = jwt.verify(token, process.env.JWT_SECRET);
+
+                const paymentId = params?.id;
+
+                if (!paymentId) {
+                        return NextResponse.json(
+                                { success: false, message: "Payment identifier is missing" },
+                                { status: 400 }
+                        );
+                }
+
+                const { transactionId, paymentMethod, note } = await request.json();
+
+                const payment = await approveEscrowPayment({
+                        paymentId,
+                        actorId: decoded?.id || null,
+                        note,
+                        transactionId,
+                        paymentMethod,
+                });
+
+                return NextResponse.json({
+                        success: true,
+                        message: "Payout approved and released",
+                        payment,
+                });
+        } catch (error) {
+                console.error("Error approving escrow payment:", error);
+                return NextResponse.json(
+                        { success: false, message: error.message || "Failed to approve payment" },
+                        { status: 400 }
+                );
+        }
+}

--- a/app/seller/orders/page.jsx
+++ b/app/seller/orders/page.jsx
@@ -111,6 +111,8 @@ function SellerOrdersPage() {
                         toast.success("Delivery confirmed successfully");
                         if (result.releaseError) {
                                 toast.error(result.releaseError);
+                        } else if (result.payment?.status === "admin_approval") {
+                                toast.success("Payout sent to admin for approval");
                         } else if (result.payment?.status === "released") {
                                 toast.success("Escrow released to your account");
                         }

--- a/app/seller/payments/page.jsx
+++ b/app/seller/payments/page.jsx
@@ -37,6 +37,7 @@ import { useIsSellerAuthenticated } from "@/store/sellerAuthStore.js";
 
 const statusStyles = {
         escrow: "bg-amber-100 text-amber-800",
+        admin_approval: "bg-blue-100 text-blue-800",
         released: "bg-emerald-100 text-emerald-800",
         refunded: "bg-red-100 text-red-800",
         cancelled: "bg-gray-100 text-gray-800",
@@ -46,6 +47,7 @@ const statusStyles = {
 const STATUS_OPTIONS = [
         { label: "All", value: "all" },
         { label: "In Escrow", value: "escrow" },
+        { label: "Awaiting Admin Approval", value: "admin_approval" },
         { label: "Released", value: "released" },
         { label: "Refunded", value: "refunded" },
         { label: "Cancelled", value: "cancelled" },
@@ -90,6 +92,13 @@ const formatSubOrderReference = (subOrderValue) => {
 
         return `#${rawValue.slice(-6)}`;
 };
+
+const formatStatus = (status) =>
+        (status || "")
+                .split("_")
+                .filter(Boolean)
+                .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+                .join(" ") || "--";
 
 function SellerPaymentsPage() {
         const router = useRouter();
@@ -332,7 +341,7 @@ function SellerPaymentsPage() {
                                                         </TableCell>
                                                                                         <TableCell>
                                                                                                 <Badge className={statusStyles[payment.status] || "bg-gray-100 text-gray-800"}>
-                                                                                                        {payment.status.charAt(0).toUpperCase() + payment.status.slice(1)}
+                                                                                                        {formatStatus(payment.status)}
                                                                                                 </Badge>
                                                                                         </TableCell>
                                                                                         <TableCell>{formatCurrency(payment.totalAmount)}</TableCell>

--- a/lib/payments/releaseEscrowPayment.js
+++ b/lib/payments/releaseEscrowPayment.js
@@ -30,7 +30,7 @@ export async function releaseEscrowPayment({
                 throw new Error("Payment record not found");
         }
 
-        if (payment.status === "released") {
+        if (payment.status === "released" || payment.status === "admin_approval") {
                 return payment;
         }
 
@@ -48,13 +48,73 @@ export async function releaseEscrowPayment({
                 }
         }
 
+        payment.status = "admin_approval";
+        payment.adminApprovalRequestedAt = new Date();
+        payment.history.push(
+                buildHistoryEntry({
+                        status: "admin_approval",
+                        note: note || "Seller delivery confirmed. Awaiting admin approval.",
+                        actorType,
+                        actorId,
+                })
+        );
+
+        await payment.save();
+
+        return payment;
+}
+
+export async function approveEscrowPayment({
+        paymentId,
+        actorId,
+        note,
+        transactionId,
+        paymentMethod,
+} = {}) {
+        if (!paymentId) {
+                throw new Error("Payment ID is required for approval");
+        }
+
+        const payment = await Payment.findById(paymentId);
+
+        if (!payment) {
+                throw new Error("Payment record not found");
+        }
+
+        if (payment.status === "released") {
+                return payment;
+        }
+
+        if (payment.status !== "admin_approval") {
+                throw new Error("Payment is not awaiting admin approval");
+        }
+
+        if (!transactionId || !transactionId.trim()) {
+                throw new Error("Transaction ID is required");
+        }
+
+        if (!paymentMethod || !paymentMethod.trim()) {
+                throw new Error("Payment method is required");
+        }
+
+        const trimmedTransactionId = transactionId.trim();
+        const trimmedMethod = paymentMethod.trim();
+
         payment.status = "released";
         payment.releasedAt = new Date();
+        payment.adminApprovedAt = new Date();
+        payment.adminApprovedBy = actorId || null;
+        payment.payoutTransactionId = trimmedTransactionId;
+        payment.payoutReference = trimmedTransactionId;
+        payment.payoutMethod = trimmedMethod;
+
         payment.history.push(
                 buildHistoryEntry({
                         status: "released",
-                        note: note || "Escrow released to seller",
-                        actorType,
+                        note:
+                                note ||
+                                `Admin approved payout via ${trimmedMethod} (Txn: ${trimmedTransactionId})`,
+                        actorType: "admin",
                         actorId,
                 })
         );


### PR DESCRIPTION
## Summary
- ensure the Payment model re-registers the schema when the admin approval status is missing
- prevent validation failures when moving payments into the admin approval state
