### PR TITLE
Ensure released payout totals ignore status filter

### DIFF
--- a/app/api/admin/payments/route.js
+++ b/app/api/admin/payments/route.js
@@ -79,8 +79,14 @@ export async function GET(request) {
                         return dateB - dateA;
                 });
 
+                const statsMatch = { ...query };
+
+                if (statsMatch.status) {
+                        delete statsMatch.status;
+                }
+
                 const [stats] = await Payment.aggregate([
-                        { $match: query },
+                        { $match: statsMatch },
                         {
                                 $group: {
                                         _id: null,


### PR DESCRIPTION
## Summary
- avoid filtering admin payment stats by the current status filter
- ensure released payout totals remain visible after an approval
