### PR TITLE
Fix SubOrder model import path

### DIFF
--- a/app/api/hexalog/webhook/route.js
+++ b/app/api/hexalog/webhook/route.js
@@ -1,5 +1,5 @@
 import dbConnect from "@/lib/dbConnect";
-import SubOrder from "@/models/SubOrder";
+import SubOrder from "@/model/SubOrder";
 import { createHmac } from "crypto";
 
 // ✅ Ensure raw body available (needed for HMAC)


### PR DESCRIPTION
## Summary
- update Hexalog webhook route to use the correct SubOrder model import path

## Testing
- npm run build (fails: external font downloads blocked in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0933bce74832e8136e4591442418f