### PR TITLE
Add seller login shortcut to registration

### DIFF
--- a/app/seller/(auth)/login/page.jsx
+++ b/app/seller/(auth)/login/page.jsx
@@ -340,6 +340,16 @@ export default function SellerLogin() {
                                                                                                         "Sign in"
                                                                                                 )}
                                                                                         </Button>
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                className="h-12 w-full rounded-xl border-orange-500/60 bg-transparent text-base font-semibold text-orange-500 transition hover:bg-orange-50 hover:text-orange-600"
+                                                                                                asChild
+                                                                                        >
+                                                                                                <Link href="/seller/register">
+                                                                                                        Create new seller account
+                                                                                                </Link>
+                                                                                        </Button>
                                                                                 </form>
                                                                         </CardContent>
                                                                 </Card>


### PR DESCRIPTION
## Summary
- add a dedicated button on the seller login form that links to the seller registration page for easier navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e094c4cbf8832eba5d24123ad9f952