### PR TITLE
Allow seller registration without auth

### DIFF
--- a/app/seller/(auth)/login/page.jsx
+++ b/app/seller/(auth)/login/page.jsx
@@ -340,6 +340,16 @@ export default function SellerLogin() {
                                                                                                         "Sign in"
                                                                                                 )}
                                                                                         </Button>
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                className="h-12 w-full rounded-xl border-orange-500/60 bg-transparent text-base font-semibold text-orange-500 transition hover:bg-orange-50 hover:text-orange-600"
+                                                                                                asChild
+                                                                                        >
+                                                                                                <Link href="/seller/register">
+                                                                                                        Create new seller account
+                                                                                                </Link>
+                                                                                        </Button>
                                                                                 </form>
                                                                         </CardContent>
                                                                 </Card>

--- a/middleware.js
+++ b/middleware.js
@@ -80,13 +80,15 @@ export function middleware(req) {
 	}
 
 	// Seller-only
-	if (pathname.startsWith("/seller")) {
-		// Allow /seller/login without token
-		if (pathname === "/seller/login") {
-			return NextResponse.next({
-				request: { headers: requestHeaders },
-			});
-		}
+        if (pathname.startsWith("/seller")) {
+                // Allow unauthenticated access to seller auth routes
+                const sellerPublicPaths = new Set(["/seller/login", "/seller/register"]);
+
+                if (sellerPublicPaths.has(pathname)) {
+                        return NextResponse.next({
+                                request: { headers: requestHeaders },
+                        });
+                }
 
 		if (!sellerToken || !isValidJWT(sellerToken)) {
 			return NextResponse.redirect(new URL("/seller/login", req.url));


### PR DESCRIPTION
## Summary
- update auth middleware to treat the seller register route as a public path
- ensure unauthenticated sellers can load the registration page from the login CTA or direct URL

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e094c4cbf8832eba5d24123ad9f952