### PR TITLE
feat: expand seller registration with company and bank details

### DIFF
--- a/app/api/seller/auth/register/route.js
+++ b/app/api/seller/auth/register/route.js
@@ -2,57 +2,113 @@ import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { dbConnect } from "@/lib/dbConnect.js";
 import User from "@/model/User";
+import Company from "@/model/companyDetails.js";
+import SellerBankDetails from "@/model/SellerBankDetails.js";
+import { sellerRegistrationSchema } from "@/zodSchema/sellerRegistrationSchema.js";
 
 export async function POST(request) {
 	try {
 		await dbConnect();
 
-		const { firstName, lastName, email, mobile, password } =
-			await request.json();
+                const body = await request.json();
+                const parsed = sellerRegistrationSchema.safeParse(body);
 
-		if (!firstName || !lastName || !email || !mobile || !password) {
-			return NextResponse.json(
-				{ success: false, message: "All fields are required" },
-				{ status: 400 }
-			);
-		}
+                if (!parsed.success) {
+                        const firstIssue = parsed.error.issues[0];
+                        return NextResponse.json(
+                                {
+                                        success: false,
+                                        message: firstIssue?.message || "Invalid registration details",
+                                },
+                                { status: 400 }
+                        );
+                }
 
-		// Check if seller already exists
-		const existingUser = await User.findOne({
-			email: email.toLowerCase(),
-		});
+                const { personalDetails, companyDetails, bankDetails } = parsed.data;
+                const { firstName, lastName, email, mobile, password } = personalDetails;
 
-		if (existingUser) {
-			return NextResponse.json(
-				{ success: false, message: "User with this email already exists" },
-				{ status: 409 }
-			);
-		}
+                // Check if seller already exists
+                const existingUser = await User.findOne({
+                        $or: [
+                                { email: email.toLowerCase() },
+                                { mobile },
+                        ],
+                });
 
-		// Hash password
+                if (existingUser) {
+                        return NextResponse.json(
+                                {
+                                        success: false,
+                                        message: "A seller with this email or mobile already exists",
+                                },
+                                { status: 409 }
+                        );
+                }
+
+                // Hash password
 		const hashedPassword = await bcrypt.hash(password, 12);
 
 		// Create new seller
-		const newSeller = new User({
-			firstName,
-			lastName,
-			email: email.toLowerCase(),
-			mobile,
-			password: hashedPassword,
-			userType: "seller",
-			isActive: true,
-			lastLogin: new Date(),
-		});
+                const newSeller = await User.create({
+                        firstName,
+                        lastName,
+                        email: email.toLowerCase(),
+                        mobile,
+                        password: hashedPassword,
+                        userType: "seller",
+                        status: "active",
+                        lastLogin: new Date(),
+                });
 
-		await newSeller.save();
+                try {
+                        const companyPayload = {
+                                user: newSeller._id,
+                                companyName: companyDetails.companyName,
+                                companyEmail: companyDetails.companyEmail,
+                                phone: companyDetails.phone,
+                                brandName: companyDetails.brandName,
+                                brandDescription: companyDetails.brandDescription,
+                                gstinNumber: companyDetails.gstinNumber,
+                                companyLogo: companyDetails.companyLogo,
+                        };
 
-		return NextResponse.json({
-			success: true,
-			message: "Seller registered successfully",
-		});
-	} catch (error) {
-		console.error("Seller registration error:", error);
-		return NextResponse.json(
+                        if (companyDetails.companyAddress?.length) {
+                                companyPayload.companyAddress = companyDetails.companyAddress;
+                        }
+
+                        const companyDoc = await Company.create(companyPayload);
+                        newSeller.company = companyDoc._id;
+                        await newSeller.save();
+
+                        await SellerBankDetails.create({
+                                user: newSeller._id,
+                                accountHolderName: bankDetails.accountHolderName,
+                                accountNumber: bankDetails.accountNumber,
+                                ifscCode: bankDetails.ifscCode,
+                                bankName: bankDetails.bankName,
+                                branchName: bankDetails.branchName,
+                        });
+                } catch (error) {
+                        await User.findByIdAndDelete(newSeller._id);
+                        if (error?.code === 11000) {
+                                return NextResponse.json(
+                                        {
+                                                success: false,
+                                                message: "Bank account is already registered with another seller",
+                                        },
+                                        { status: 409 }
+                                );
+                        }
+                        throw error;
+                }
+
+                return NextResponse.json({
+                        success: true,
+                        message: "Seller registered successfully",
+                });
+        } catch (error) {
+                console.error("Seller registration error:", error);
+                return NextResponse.json(
 			{ success: false, message: "Internal server error" },
 			{ status: 500 }
 		);

--- a/app/seller/(auth)/register/page.jsx
+++ b/app/seller/(auth)/register/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -8,359 +8,751 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import {
-	useSellerAuthStore,
-	useIsSellerAuthenticated,
+        useSellerAuthStore,
+        useIsSellerAuthenticated,
 } from "@/store/sellerAuthStore";
 import { toast } from "react-hot-toast";
 import Logo from "@/public/SafetyLogo.png";
 import LoginModel from "@/public/images/login/LoginModel.png";
+import {
+        emptyCompanyAddress,
+        mapFormToRegistrationPayload,
+        normalizeCompanyAddressInput,
+        sellerBankDetailsFormSchema,
+        sellerCompanyDetailsSchema,
+        sellerPersonalDetailsFormSchema,
+        sellerRegistrationSchema,
+} from "@/zodSchema/sellerRegistrationSchema.js";
+
+const steps = [
+        {
+                title: "Personal Details",
+                description: "Tell us about yourself to create your seller account.",
+        },
+        {
+                title: "Company Details",
+                description: "Share your business information for verification.",
+        },
+        {
+                title: "Bank Details",
+                description: "Provide payout information to receive settlements.",
+        },
+];
 
 export default function SellerRegister() {
-	const [formData, setFormData] = useState({
-		firstName: "",
-		lastName: "",
-		email: "",
-		mobile: "",
-		password: "",
-		confirmPassword: "",
-	});
-	const [showPassword, setShowPassword] = useState(false);
-	const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-	const [isLoading, setIsLoading] = useState(false);
+        const [step, setStep] = useState(0);
+        const [personalDetails, setPersonalDetails] = useState({
+                firstName: "",
+                lastName: "",
+                email: "",
+                mobile: "",
+                password: "",
+                confirmPassword: "",
+        });
+        const [companyDetails, setCompanyDetails] = useState({
+                companyName: "",
+                companyEmail: "",
+                phone: "",
+                brandName: "",
+                brandDescription: "",
+                gstinNumber: "",
+                companyLogo: "",
+        });
+        const [companyAddress, setCompanyAddress] = useState(emptyCompanyAddress());
+        const [includeCompanyAddress, setIncludeCompanyAddress] = useState(false);
+        const [bankDetails, setBankDetails] = useState({
+                accountHolderName: "",
+                accountNumber: "",
+                confirmAccountNumber: "",
+                ifscCode: "",
+                bankName: "",
+                branchName: "",
+        });
+        const [showPassword, setShowPassword] = useState(false);
+        const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+        const [isLoading, setIsLoading] = useState(false);
 
-	const router = useRouter();
-	const { register } = useSellerAuthStore();
-	const isAuthenticated = useIsSellerAuthenticated();
+        const router = useRouter();
+        const { register } = useSellerAuthStore();
+        const isAuthenticated = useIsSellerAuthenticated();
 
-	useEffect(() => {
-		if (isAuthenticated) {
-			router.push("/seller/dashboard");
-		}
-	}, [isAuthenticated, router]);
+        useEffect(() => {
+                if (isAuthenticated) {
+                        router.push("/seller/dashboard");
+                }
+        }, [isAuthenticated, router]);
 
-	const handleInputChange = (e) => {
-		const { name, value } = e.target;
-		setFormData((prev) => ({
-			...prev,
-			[name]: value,
-		}));
-	};
+        const progress = useMemo(
+                () => Math.round(((step + 1) / steps.length) * 100),
+                [step]
+        );
 
-	const handleSubmit = async (e) => {
-		e.preventDefault();
+        const handlePersonalChange = (event) => {
+                const { name, value } = event.target;
+                let nextValue = value;
+                if (name === "mobile") {
+                        nextValue = value.replace(/\D/g, "").slice(0, 15);
+                }
+                setPersonalDetails((prev) => ({
+                        ...prev,
+                        [name]: nextValue,
+                }));
+        };
 
-		if (!e.currentTarget.checkValidity()) {
+        const handleCompanyChange = (event) => {
+                const { name, value } = event.target;
+                let nextValue = value;
+                if (name === "phone") {
+                        nextValue = value.replace(/\D/g, "").slice(0, 15);
+                }
+                if (name === "gstinNumber") {
+                        nextValue = value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 20);
+                }
+                setCompanyDetails((prev) => ({
+                        ...prev,
+                        [name]: nextValue,
+                }));
+        };
 
-		  e.currentTarget.reportValidity();
+        const handleCompanyAddressChange = (event) => {
+                const { name, value } = event.target;
+                let nextValue = value;
+                if (name === "pincode") {
+                        nextValue = value.replace(/\D/g, "").slice(0, 10);
+                }
+                setCompanyAddress((prev) => ({
+                        ...prev,
+                        [name]: nextValue,
+                }));
+        };
 
-		  return;
+        const handleBankChange = (event) => {
+                const { name, value } = event.target;
+                let nextValue = value;
+                if (name === "accountNumber" || name === "confirmAccountNumber") {
+                        nextValue = value.replace(/\D/g, "").slice(0, 18);
+                }
+                if (name === "ifscCode") {
+                        nextValue = value
+                                .toUpperCase()
+                                .replace(/[^A-Z0-9]/g, "")
+                                .slice(0, 11);
+                }
+                setBankDetails((prev) => ({
+                        ...prev,
+                        [name]: nextValue,
+                }));
+        };
 
-		}
-		setIsLoading(true);
+        const handleBack = () => {
+                setStep((prev) => Math.max(prev - 1, 0));
+        };
 
-		// Validation
-		if (
-			!formData.firstName ||
-			!formData.lastName ||
-			!formData.email ||
-			!formData.mobile ||
-			!formData.password
-		) {
-			toast.error("Please fill in all fields");
-			setIsLoading(false);
-			return;
-		}
+        const handleStepSubmit = async (event) => {
+                event.preventDefault();
 
-		if (formData.password !== formData.confirmPassword) {
-			toast.error("Passwords do not match");
-			setIsLoading(false);
-			return;
-		}
+                if (step === 0) {
+                        const parsed = sellerPersonalDetailsFormSchema.safeParse(
+                                personalDetails
+                        );
+                        if (!parsed.success) {
+                                toast.error(parsed.error.issues[0]?.message || "Invalid details");
+                                return;
+                        }
+                        setStep(1);
+                        return;
+                }
 
-		if (formData.password.length < 6) {
-			toast.error("Password must be at least 6 characters long");
-			setIsLoading(false);
-			return;
-		}
+                if (step === 1) {
+                        const normalizedAddress = includeCompanyAddress
+                                ? normalizeCompanyAddressInput(companyAddress)
+                                : [];
+                        const parsed = sellerCompanyDetailsSchema.safeParse({
+                                ...companyDetails,
+                                companyAddress: normalizedAddress,
+                        });
+                        if (!parsed.success) {
+                                toast.error(
+                                        parsed.error.issues[0]?.message || "Check your company details"
+                                );
+                                return;
+                        }
+                        setStep(2);
+                        return;
+                }
 
-		const { confirmPassword, ...registrationData } = formData;
-		const result = await register(registrationData);
+                const parsedBank = sellerBankDetailsFormSchema.safeParse(bankDetails);
+                if (!parsedBank.success) {
+                        toast.error(parsedBank.error.issues[0]?.message || "Invalid bank details");
+                        return;
+                }
 
-		if (result.success) {
-			router.push("/seller/login");
-		}
+                const { confirmAccountNumber, ...bankPayload } = parsedBank.data;
+                const normalizedAddress = includeCompanyAddress
+                        ? normalizeCompanyAddressInput(companyAddress)
+                        : [];
 
-		setIsLoading(false);
-	};
+                const payload = mapFormToRegistrationPayload({
+                        personalDetails,
+                        companyDetails: {
+                                ...companyDetails,
+                                companyAddress: normalizedAddress,
+                        },
+                        bankDetails: bankPayload,
+                });
 
-	if (isAuthenticated) {
-		return (
-			<div className="min-h-screen flex items-center justify-center">
-				<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"></div>
-			</div>
-		);
-	}
+                const registrationCheck = sellerRegistrationSchema.safeParse(payload);
+                if (!registrationCheck.success) {
+                        toast.error(
+                                registrationCheck.error.issues[0]?.message ||
+                                        "Unable to submit registration"
+                        );
+                        return;
+                }
 
-	const containerVariants = {
-		hidden: { opacity: 0 },
-		visible: {
-			opacity: 1,
-			transition: {
-				duration: 0.6,
-				staggerChildren: 0.1,
-			},
-		},
-	};
+                setIsLoading(true);
+                try {
+                        const result = await register(registrationCheck.data);
+                        if (result.success) {
+                                router.push("/seller/login");
+                        }
+                } catch (error) {
+                        console.error("Seller registration failed", error);
+                        toast.error("Registration failed. Please try again.");
+                } finally {
+                        setIsLoading(false);
+                }
+        };
 
-	const itemVariants = {
-		hidden: { y: 20, opacity: 0 },
-		visible: {
-			y: 0,
-			opacity: 1,
-			transition: {
-				duration: 0.5,
-			},
-		},
-	};
+        if (isAuthenticated) {
+                return (
+                        <div className="min-h-screen flex items-center justify-center">
+                                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"></div>
+                        </div>
+                );
+        }
 
-	return (
-		<div className="max-w-7xl mx-auto min-h-screen grid grid-cols-2 lg:px-10">
-			{/* Left side - Image and branding */}
-			<motion.div
-				className="hidden lg:flex justify-center items-center overflow-hidden my-12 px-8"
-				initial={{ x: -100, opacity: 0 }}
-				animate={{ x: 0, opacity: 1 }}
-				transition={{ duration: 0.8, ease: "easeOut" }}
-			>
-				<div className="w-4/5 py-8 bg-[#F3F3F3] rounded-2xl">
-					<motion.div
-						className="w-full"
-						variants={containerVariants}
-						initial="hidden"
-						animate="visible"
-					>
-						<motion.h1
-							className="text-2xl lg:text-3xl font-bold text-gray-800 mb-2 text-center"
-							variants={itemVariants}
-						>
-							JOIN OUR COMMUNITY
-						</motion.h1>
-						<motion.p
-							className="text-gray-600 lg:text-xl font-medium tracking-wider text-center"
-							variants={itemVariants}
-						>
-							START YOUR JOURNEY TODAY
-						</motion.p>
-					</motion.div>
+        const containerVariants = {
+                hidden: { opacity: 0 },
+                visible: {
+                        opacity: 1,
+                        transition: {
+                                duration: 0.6,
+                                staggerChildren: 0.1,
+                        },
+                },
+        };
 
-					<div className="flex items-center justify-center">
-						<motion.div
-							initial={{ scale: 0.9, opacity: 0 }}
-							animate={{ scale: 1, opacity: 1 }}
-							transition={{ duration: 1, delay: 0.3 }}
-							className="w-full max-w-[400px] h-1/2 overflow-hidden"
-						>
-							<Image
-								src={LoginModel.src}
-								alt="Welcome"
-								width={400}
-								height={400}
-								className="w-full h-full object-cover"
-							/>
-						</motion.div>
-					</div>
-				</div>
-			</motion.div>
+        const itemVariants = {
+                hidden: { y: 20, opacity: 0 },
+                visible: {
+                        y: 0,
+                        opacity: 1,
+                        transition: {
+                                duration: 0.5,
+                        },
+                },
+        };
 
-			{/* Right side - Signup form */}
-			<motion.div
-				className="my-12 col-span-2 md:col-span-1 flex-1 flex justify-center px-8 bg-white h-[calc(100vh-96px)] overflow-auto hide-scrollbar"
-				initial={{ x: 100, opacity: 0 }}
-				animate={{ x: 0, opacity: 1 }}
-				transition={{ duration: 0.8, ease: "easeOut", delay: 0.2 }}
-			>
-				<div className="w-full max-w-md">
-					<motion.div
-						className="text-center mb-6"
-						initial={{ scale: 0.8, opacity: 0 }}
-						animate={{ scale: 1, opacity: 1 }}
-						transition={{ duration: 0.5, ease: "easeOut" }}
-					>
-						<Image
-							src={Logo.src}
-							alt="Logo"
-							width={100}
-							height={100}
-							className="w-[100] h-auto object-cover"
-						/>
-					</motion.div>
+        return (
+                <div className="max-w-7xl mx-auto min-h-screen grid grid-cols-2 lg:px-10">
+                        {/* Left side - Image and branding */}
+                        <motion.div
+                                className="hidden lg:flex justify-center items-center overflow-hidden my-12 px-8"
+                                initial={{ x: -100, opacity: 0 }}
+                                animate={{ x: 0, opacity: 1 }}
+                                transition={{ duration: 0.8, ease: "easeOut" }}
+                        >
+                                <div className="w-4/5 py-8 bg-[#F3F3F3] rounded-2xl">
+                                        <motion.div
+                                                className="w-full"
+                                                variants={containerVariants}
+                                                initial="hidden"
+                                                animate="visible"
+                                        >
+                                                <motion.h1
+                                                        className="text-2xl lg:text-3xl font-bold text-gray-800 mb-2 text-center"
+                                                        variants={itemVariants}
+                                                >
+                                                        JOIN OUR COMMUNITY
+                                                </motion.h1>
+                                                <motion.p
+                                                        className="text-gray-600 lg:text-xl font-medium tracking-wider text-center"
+                                                        variants={itemVariants}
+                                                >
+                                                        START YOUR JOURNEY TODAY
+                                                </motion.p>
+                                        </motion.div>
 
-					<motion.div
-						variants={containerVariants}
-						initial="hidden"
-						animate="visible"
-					>
-						<Card className="border-0 shadow-none">
-							<CardHeader className="space-y-1 p-0 mb-4">
-								<motion.div variants={itemVariants}>
-									<CardTitle className="text-2xl font-bold text-gray-800">
-										Seller Registration
-									</CardTitle>
-								</motion.div>
-								<motion.div variants={itemVariants}>
-									<CardDescription className="text-gray-600">
-										Already have an account?{" "}
-										<Link
-											href="/seller/login"
-											className="text-black hover:text-blue-700 font-medium underline"
-										>
-											Sign In
-										</Link>
-									</CardDescription>
-								</motion.div>
-							</CardHeader>
-							<CardContent className="p-0">
-								<form onSubmit={handleSubmit} className="space-y-4">
-									<div className="grid grid-cols-2 gap-4">
-										<div className="space-y-2">
-											<Label htmlFor="firstName">First Name</Label>
-											<Input
-												id="firstName"
-												name="firstName"
-												type="text"
-												placeholder="First name"
-												value={formData.firstName}
-												onChange={handleInputChange}
-												required
-											/>
-										</div>
-										<div className="space-y-2">
-											<Label htmlFor="lastName">Last Name</Label>
-											<Input
-												id="lastName"
-												name="lastName"
-												type="text"
-												placeholder="Last name"
-												value={formData.lastName}
-												onChange={handleInputChange}
-												required
-											/>
-										</div>
-									</div>
+                                        <div className="flex items-center justify-center">
+                                                <motion.div
+                                                        initial={{ scale: 0.9, opacity: 0 }}
+                                                        animate={{ scale: 1, opacity: 1 }}
+                                                        transition={{ duration: 1, delay: 0.3 }}
+                                                        className="w-full max-w-[400px] h-1/2 overflow-hidden"
+                                                >
+                                                        <Image
+                                                                src={LoginModel.src}
+                                                                alt="Welcome"
+                                                                width={400}
+                                                                height={400}
+                                                                className="w-full h-full object-cover"
+                                                        />
+                                                </motion.div>
+                                        </div>
+                                </div>
+                        </motion.div>
 
-									<div className="space-y-2">
-										<Label htmlFor="email">Email</Label>
-										<Input
-											id="email"
-											name="email"
-											type="email"
-											placeholder="Enter your email"
-											value={formData.email}
-											onChange={handleInputChange}
-											required
-										/>
-									</div>
+                        {/* Right side - Signup form */}
+                        <motion.div
+                                className="my-12 col-span-2 md:col-span-1 flex-1 flex justify-center px-8 bg-white h-[calc(100vh-96px)] overflow-auto hide-scrollbar"
+                                initial={{ x: 100, opacity: 0 }}
+                                animate={{ x: 0, opacity: 1 }}
+                                transition={{ duration: 0.8, ease: "easeOut", delay: 0.2 }}
+                        >
+                                <div className="w-full max-w-md">
+                                        <motion.div
+                                                className="text-center mb-6"
+                                                initial={{ scale: 0.8, opacity: 0 }}
+                                                animate={{ scale: 1, opacity: 1 }}
+                                                transition={{ duration: 0.5, ease: "easeOut" }}
+                                        >
+                                                <Image
+                                                        src={Logo.src}
+                                                        alt="Logo"
+                                                        width={100}
+                                                        height={100}
+                                                        className="w-[100] h-auto object-cover"
+                                                />
+                                        </motion.div>
 
-									<div className="space-y-2">
-										<Label htmlFor="mobile">Mobile Number</Label>
-										<Input
-											id="mobile"
-											name="mobile"
-											type="tel"
-											placeholder="Enter your mobile number"
-											value={formData.mobile}
-											onChange={handleInputChange}
-											required
-										/>
-									</div>
+                                        <motion.div
+                                                variants={containerVariants}
+                                                initial="hidden"
+                                                animate="visible"
+                                        >
+                                                <Card className="border-0 shadow-none">
+                                                        <CardHeader className="space-y-3 p-0 mb-4">
+                                                                <motion.div variants={itemVariants} className="space-y-1">
+                                                                        <p className="text-sm font-medium text-gray-500">
+                                                                                Step {step + 1} of {steps.length} · {progress}% complete
+                                                                        </p>
+                                                                        <CardTitle className="text-2xl font-bold text-gray-800">
+                                                                                {steps[step].title}
+                                                                        </CardTitle>
+                                                                </motion.div>
+                                                                <motion.div variants={itemVariants} className="space-y-2">
+                                                                        <CardDescription className="text-gray-600">
+                                                                                {steps[step].description}
+                                                                        </CardDescription>
+                                                                        <p className="text-sm text-gray-600">
+                                                                                Already have an account?{" "}
+                                                                                <Link
+                                                                                        href="/seller/login"
+                                                                                        className="text-black hover:text-blue-700 font-medium underline"
+                                                                                >
+                                                                                        Sign In
+                                                                                </Link>
+                                                                        </p>
+                                                                </motion.div>
+                                                        </CardHeader>
+                                                        <CardContent className="p-0">
+                                                                <form onSubmit={handleStepSubmit} className="space-y-6">
+                                                                        {step === 0 && (
+                                                                                <div className="space-y-4">
+                                                                                        <div className="grid grid-cols-2 gap-4">
+                                                                                                <div className="space-y-2">
+                                                                                                        <Label htmlFor="firstName">First Name</Label>
+                                                                                                        <Input
+                                                                                                                id="firstName"
+                                                                                                                name="firstName"
+                                                                                                                type="text"
+                                                                                                                placeholder="First name"
+                                                                                                                value={personalDetails.firstName}
+                                                                                                                onChange={handlePersonalChange}
+                                                                                                                required
+                                                                                                        />
+                                                                                                </div>
+                                                                                                <div className="space-y-2">
+                                                                                                        <Label htmlFor="lastName">Last Name</Label>
+                                                                                                        <Input
+                                                                                                                id="lastName"
+                                                                                                                name="lastName"
+                                                                                                                type="text"
+                                                                                                                placeholder="Last name"
+                                                                                                                value={personalDetails.lastName}
+                                                                                                                onChange={handlePersonalChange}
+                                                                                                                required
+                                                                                                        />
+                                                                                                </div>
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="email">Email</Label>
+                                                                                                <Input
+                                                                                                        id="email"
+                                                                                                        name="email"
+                                                                                                        type="email"
+                                                                                                        placeholder="Enter your email"
+                                                                                                        value={personalDetails.email}
+                                                                                                        onChange={handlePersonalChange}
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="mobile">Mobile Number</Label>
+                                                                                                <Input
+                                                                                                        id="mobile"
+                                                                                                        name="mobile"
+                                                                                                        inputMode="tel"
+                                                                                                        placeholder="Enter your mobile number"
+                                                                                                        value={personalDetails.mobile}
+                                                                                                        onChange={handlePersonalChange}
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="password">Password</Label>
+                                                                                                <div className="relative">
+                                                                                                        <Input
+                                                                                                                id="password"
+                                                                                                                name="password"
+                                                                                                                type={showPassword ? "text" : "password"}
+                                                                                                                placeholder="Enter your password"
+                                                                                                                value={personalDetails.password}
+                                                                                                                onChange={handlePersonalChange}
+                                                                                                                required
+                                                                                                        />
+                                                                                                        <Button
+                                                                                                                type="button"
+                                                                                                                variant="ghost"
+                                                                                                                size="sm"
+                                                                                                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                                                                                                                onClick={() => setShowPassword((prev) => !prev)}
+                                                                                                        >
+                                                                                                                {showPassword ? (
+                                                                                                                        <EyeOff className="h-4 w-4" />
+                                                                                                                ) : (
+                                                                                                                        <Eye className="h-4 w-4" />
+                                                                                                                )}
+                                                                                                        </Button>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="confirmPassword">Confirm Password</Label>
+                                                                                                <div className="relative">
+                                                                                                        <Input
+                                                                                                                id="confirmPassword"
+                                                                                                                name="confirmPassword"
+                                                                                                                type={showConfirmPassword ? "text" : "password"}
+                                                                                                                placeholder="Confirm your password"
+                                                                                                                value={personalDetails.confirmPassword}
+                                                                                                                onChange={handlePersonalChange}
+                                                                                                                required
+                                                                                                        />
+                                                                                                        <Button
+                                                                                                                type="button"
+                                                                                                                variant="ghost"
+                                                                                                                size="sm"
+                                                                                                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                                                                                                                onClick={() =>
+                                                                                                                        setShowConfirmPassword((prev) => !prev)
+                                                                                                                }
+                                                                                                        >
+                                                                                                                {showConfirmPassword ? (
+                                                                                                                        <EyeOff className="h-4 w-4" />
+                                                                                                                ) : (
+                                                                                                                        <Eye className="h-4 w-4" />
+                                                                                                                )}
+                                                                                                        </Button>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                        )}
 
-									<div className="space-y-2">
-										<Label htmlFor="password">Password</Label>
-										<div className="relative">
-											<Input
-												id="password"
-												name="password"
-												type={showPassword ? "text" : "password"}
-												placeholder="Enter your password"
-												value={formData.password}
-												onChange={handleInputChange}
-												required
-											/>
-											<Button
-												type="button"
-												variant="ghost"
-												size="sm"
-												className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-												onClick={() => setShowPassword(!showPassword)}
-											>
-												{showPassword ? (
-													<EyeOff className="h-4 w-4" />
-												) : (
-													<Eye className="h-4 w-4" />
-												)}
-											</Button>
-										</div>
-									</div>
+                                                                        {step === 1 && (
+                                                                                <div className="space-y-4">
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="companyName">Company Name</Label>
+                                                                                                <Input
+                                                                                                        id="companyName"
+                                                                                                        name="companyName"
+                                                                                                        value={companyDetails.companyName}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="Registered company name"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="companyEmail">Company Email</Label>
+                                                                                                <Input
+                                                                                                        id="companyEmail"
+                                                                                                        name="companyEmail"
+                                                                                                        type="email"
+                                                                                                        value={companyDetails.companyEmail}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="support@company.com"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="phone">Company Phone</Label>
+                                                                                                <Input
+                                                                                                        id="phone"
+                                                                                                        name="phone"
+                                                                                                        inputMode="tel"
+                                                                                                        value={companyDetails.phone}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="Company contact number"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="brandName">Brand Name (optional)</Label>
+                                                                                                <Input
+                                                                                                        id="brandName"
+                                                                                                        name="brandName"
+                                                                                                        value={companyDetails.brandName}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="Trading / brand name"
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="brandDescription">Brand Description (optional)</Label>
+                                                                                                <Textarea
+                                                                                                        id="brandDescription"
+                                                                                                        name="brandDescription"
+                                                                                                        value={companyDetails.brandDescription}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="Describe your products or services"
+                                                                                                        rows={3}
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="gstinNumber">GSTIN (optional)</Label>
+                                                                                                <Input
+                                                                                                        id="gstinNumber"
+                                                                                                        name="gstinNumber"
+                                                                                                        value={companyDetails.gstinNumber}
+                                                                                                        onChange={handleCompanyChange}
+                                                                                                        placeholder="22AAAAA0000A1Z5"
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="flex items-center gap-3 rounded-md border border-gray-200 p-3">
+                                                                                                <Checkbox
+                                                                                                        id="include-address"
+                                                                                                        checked={includeCompanyAddress}
+                                                                                                        onCheckedChange={(checked) =>
+                                                                                                                setIncludeCompanyAddress(Boolean(checked))
+                                                                                                        }
+                                                                                                />
+                                                                                                <Label
+                                                                                                        htmlFor="include-address"
+                                                                                                        className="text-sm font-medium text-gray-700"
+                                                                                                >
+                                                                                                        Add primary pickup address now
+                                                                                                </Label>
+                                                                                        </div>
+                                                                                        {includeCompanyAddress && (
+                                                                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="tagName">Address Label</Label>
+                                                                                                                <Input
+                                                                                                                        id="tagName"
+                                                                                                                        name="tagName"
+                                                                                                                        value={companyAddress.tagName}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="Head Office"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="building">Building</Label>
+                                                                                                                <Input
+                                                                                                                        id="building"
+                                                                                                                        name="building"
+                                                                                                                        value={companyAddress.building}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="Building / Flat"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="street">Street</Label>
+                                                                                                                <Input
+                                                                                                                        id="street"
+                                                                                                                        name="street"
+                                                                                                                        value={companyAddress.street}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="Street / Area"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="city">City</Label>
+                                                                                                                <Input
+                                                                                                                        id="city"
+                                                                                                                        name="city"
+                                                                                                                        value={companyAddress.city}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="City"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="state">State</Label>
+                                                                                                                <Input
+                                                                                                                        id="state"
+                                                                                                                        name="state"
+                                                                                                                        value={companyAddress.state}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="State"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2">
+                                                                                                                <Label htmlFor="pincode">Pincode</Label>
+                                                                                                                <Input
+                                                                                                                        id="pincode"
+                                                                                                                        name="pincode"
+                                                                                                                        inputMode="numeric"
+                                                                                                                        value={companyAddress.pincode}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="Postal code"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                        <div className="space-y-2 md:col-span-2">
+                                                                                                                <Label htmlFor="country">Country</Label>
+                                                                                                                <Input
+                                                                                                                        id="country"
+                                                                                                                        name="country"
+                                                                                                                        value={companyAddress.country}
+                                                                                                                        onChange={handleCompanyAddressChange}
+                                                                                                                        placeholder="Country"
+                                                                                                                />
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                        )}
+                                                                                </div>
+                                                                        )}
 
-									<div className="space-y-2">
-										<Label htmlFor="confirmPassword">Confirm Password</Label>
-										<div className="relative">
-											<Input
-												id="confirmPassword"
-												name="confirmPassword"
-												type={showConfirmPassword ? "text" : "password"}
-												placeholder="Confirm your password"
-												value={formData.confirmPassword}
-												onChange={handleInputChange}
-												required
-											/>
-											<Button
-												type="button"
-												variant="ghost"
-												size="sm"
-												className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-												onClick={() =>
-													setShowConfirmPassword(!showConfirmPassword)
-												}
-											>
-												{showConfirmPassword ? (
-													<EyeOff className="h-4 w-4" />
-												) : (
-													<Eye className="h-4 w-4" />
-												)}
-											</Button>
-										</div>
-									</div>
+                                                                        {step === 2 && (
+                                                                                <div className="space-y-4">
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="accountHolderName">Account Holder Name</Label>
+                                                                                                <Input
+                                                                                                        id="accountHolderName"
+                                                                                                        name="accountHolderName"
+                                                                                                        value={bankDetails.accountHolderName}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="As per bank records"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="accountNumber">Account Number</Label>
+                                                                                                <Input
+                                                                                                        id="accountNumber"
+                                                                                                        name="accountNumber"
+                                                                                                        inputMode="numeric"
+                                                                                                        value={bankDetails.accountNumber}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="Enter account number"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="confirmAccountNumber">Confirm Account Number</Label>
+                                                                                                <Input
+                                                                                                        id="confirmAccountNumber"
+                                                                                                        name="confirmAccountNumber"
+                                                                                                        inputMode="numeric"
+                                                                                                        value={bankDetails.confirmAccountNumber}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="Re-enter account number"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="ifscCode">IFSC Code</Label>
+                                                                                                <Input
+                                                                                                        id="ifscCode"
+                                                                                                        name="ifscCode"
+                                                                                                        value={bankDetails.ifscCode}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="SBIN0001234"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="bankName">Bank Name</Label>
+                                                                                                <Input
+                                                                                                        id="bankName"
+                                                                                                        name="bankName"
+                                                                                                        value={bankDetails.bankName}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="Bank name"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                        <div className="space-y-2">
+                                                                                                <Label htmlFor="branchName">Branch Name</Label>
+                                                                                                <Input
+                                                                                                        id="branchName"
+                                                                                                        name="branchName"
+                                                                                                        value={bankDetails.branchName}
+                                                                                                        onChange={handleBankChange}
+                                                                                                        placeholder="Branch name"
+                                                                                                        required
+                                                                                                />
+                                                                                        </div>
+                                                                                </div>
+                                                                        )}
 
-									<Button
-										type="submit"
-										className="w-full bg-gray-800 hover:bg-gray-900 text-white font-medium text-base"
-										disabled={isLoading}
-									>
-										{isLoading ? (
-											<>
-												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-												Creating account...
-											</>
-										) : (
-											"Create Account"
-										)}
-									</Button>
-								</form>
-							</CardContent>
-						</Card>
-					</motion.div>
-				</div>
-			</motion.div>
-		</div>
-	);
+                                                                        <div className="flex items-center justify-between gap-4">
+                                                                                {step > 0 ? (
+                                                                                        <Button
+                                                                                                type="button"
+                                                                                                variant="outline"
+                                                                                                onClick={handleBack}
+                                                                                                className="flex-1"
+                                                                                                disabled={isLoading}
+                                                                                        >
+                                                                                                Back
+                                                                                        </Button>
+                                                                                ) : (
+                                                                                        <div />
+                                                                                )}
+                                                                                <Button
+                                                                                        type="submit"
+                                                                                        className="flex-1 bg-gray-800 hover:bg-gray-900 text-white"
+                                                                                        disabled={isLoading}
+                                                                                >
+                                                                                        {isLoading ? (
+                                                                                                <>
+                                                                                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                                                                                        Processing...
+                                                                                                </>
+                                                                                        ) : step === steps.length - 1 ? (
+                                                                                                "Create Account"
+                                                                                        ) : step === 0 ? (
+                                                                                                "Continue to Company Details"
+                                                                                        ) : (
+                                                                                                "Continue to Bank Details"
+                                                                                        )}
+                                                                                </Button>
+                                                                        </div>
+                                                                </form>
+                                                        </CardContent>
+                                                </Card>
+                                        </motion.div>
+                                </div>
+                        </motion.div>
+                </div>
+        );
 }

--- a/model/SellerBankDetails.js
+++ b/model/SellerBankDetails.js
@@ -1,0 +1,46 @@
+import mongoose from "mongoose";
+
+const { Schema } = mongoose;
+
+const SellerBankDetailsSchema = new Schema(
+        {
+                user: {
+                        type: Schema.Types.ObjectId,
+                        ref: "User",
+                        required: true,
+                        unique: true,
+                },
+                accountHolderName: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                },
+                accountNumber: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                },
+                ifscCode: {
+                        type: String,
+                        required: true,
+                        uppercase: true,
+                        trim: true,
+                },
+                bankName: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                },
+                branchName: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                },
+        },
+        { timestamps: true }
+);
+
+SellerBankDetailsSchema.index({ accountNumber: 1, ifscCode: 1 }, { unique: true, sparse: true });
+
+export default mongoose.models.SellerBankDetails ||
+        mongoose.model("SellerBankDetails", SellerBankDetailsSchema);

--- a/store/sellerAuthStore.js
+++ b/store/sellerAuthStore.js
@@ -50,33 +50,34 @@ export const useSellerAuthStore = create(
 				},
 
 				// Register seller
-				register: async (sellerData) => {
-					set({ loading: true, error: null });
-					try {
-						const response = await fetch("/api/seller/auth/register", {
-							method: "POST",
-							headers: {
-								"Content-Type": "application/json",
-							},
-							body: JSON.stringify(sellerData),
-						});
+                                register: async (sellerData) => {
+                                        set({ loading: true, error: null });
+                                        try {
+                                                const response = await fetch("/api/seller/auth/register", {
+                                                        method: "POST",
+                                                        headers: {
+                                                                "Content-Type": "application/json",
+                                                        },
+                                                        body: JSON.stringify(sellerData),
+                                                });
 
-						const data = await response.json();
+                                                const data = await response.json();
 
-						if (data.success) {
-							toast.success("Registration successful! Please login.");
-							return { success: true };
-						} else {
-							set({ error: data.message, loading: false });
-							toast.error(data.message);
-							return { success: false, message: data.message };
-						}
-					} catch (error) {
-						set({ error: "Registration failed", loading: false });
-						toast.error("Registration failed");
-						return { success: false, message: "Registration failed" };
-					}
-				},
+                                                if (data.success) {
+                                                        set({ loading: false });
+                                                        toast.success("Registration successful! Please login.");
+                                                        return { success: true };
+                                                } else {
+                                                        set({ error: data.message, loading: false });
+                                                        toast.error(data.message);
+                                                        return { success: false, message: data.message };
+                                                }
+                                        } catch (error) {
+                                                set({ error: "Registration failed", loading: false });
+                                                toast.error("Registration failed");
+                                                return { success: false, message: "Registration failed" };
+                                        }
+                                },
 
 				// Update profile
 				updateProfile: async (profileData) => {

--- a/zodSchema/sellerRegistrationSchema.js
+++ b/zodSchema/sellerRegistrationSchema.js
@@ -1,0 +1,156 @@
+import { z } from "zod";
+import { addressSchema, companyCreateSchema, phoneRegex } from "./companyScema.js";
+
+const indianMobileRegex = phoneRegex;
+
+export const sellerPersonalDetailsSchema = z.object({
+        firstName: z
+                .string({ required_error: "First name is required" })
+                .trim()
+                .min(1, "First name is required"),
+        lastName: z
+                .string({ required_error: "Last name is required" })
+                .trim()
+                .min(1, "Last name is required"),
+        email: z
+                .string({ required_error: "Email is required" })
+                .trim()
+                .email("Enter a valid email"),
+        mobile: z
+                .string({ required_error: "Mobile number is required" })
+                .trim()
+                .regex(indianMobileRegex, "Enter a valid mobile number"),
+        password: z
+                .string({ required_error: "Password is required" })
+                .min(8, "Password must be at least 8 characters"),
+});
+
+export const sellerPersonalDetailsFormSchema = sellerPersonalDetailsSchema.extend({
+        confirmPassword: z
+                .string({ required_error: "Confirm your password" })
+                .min(8, "Password must be at least 8 characters"),
+}).refine((data) => data.password === data.confirmPassword, {
+        message: "Passwords do not match",
+        path: ["confirmPassword"],
+});
+
+export const sellerCompanyDetailsSchema = companyCreateSchema;
+
+const ifscRegex = /^[A-Z]{4}0[A-Z0-9]{6}$/i;
+const accountNumberRegex = /^\d{9,18}$/;
+
+export const sellerBankDetailsSchema = z.object({
+        accountHolderName: z
+                .string({ required_error: "Account holder name is required" })
+                .trim()
+                .min(2, "Account holder name must be at least 2 characters"),
+        accountNumber: z
+                .string({ required_error: "Account number is required" })
+                .trim()
+                .regex(accountNumberRegex, "Enter a valid account number"),
+        ifscCode: z
+                .string({ required_error: "IFSC code is required" })
+                .trim()
+                .toUpperCase()
+                .regex(ifscRegex, "Enter a valid IFSC code"),
+        bankName: z
+                .string({ required_error: "Bank name is required" })
+                .trim()
+                .min(2, "Bank name is required"),
+        branchName: z
+                .string({ required_error: "Branch name is required" })
+                .trim()
+                .min(2, "Branch name is required"),
+});
+
+export const sellerBankDetailsFormSchema = sellerBankDetailsSchema.extend({
+        confirmAccountNumber: z
+                .string({ required_error: "Confirm your account number" })
+                .trim()
+                .regex(accountNumberRegex, "Enter a valid account number"),
+}).refine((data) => data.accountNumber === data.confirmAccountNumber, {
+        message: "Account numbers do not match",
+        path: ["confirmAccountNumber"],
+});
+
+export const sellerRegistrationSchema = z.object({
+        personalDetails: sellerPersonalDetailsSchema,
+        companyDetails: sellerCompanyDetailsSchema,
+        bankDetails: sellerBankDetailsSchema,
+});
+
+export const mapFormToRegistrationPayload = ({
+        personalDetails,
+        companyDetails,
+        bankDetails,
+}) => {
+        const normalizedAddresses = normalizeCompanyAddressInput(
+                companyDetails.companyAddress
+        );
+        const mappedCompany = { ...companyDetails };
+        if (normalizedAddresses.length === 0) {
+                delete mappedCompany.companyAddress;
+        } else {
+                mappedCompany.companyAddress = normalizedAddresses;
+        }
+
+        return {
+                personalDetails: {
+                        firstName: personalDetails.firstName.trim(),
+                        lastName: personalDetails.lastName.trim(),
+                        email: personalDetails.email.trim().toLowerCase(),
+                        mobile: personalDetails.mobile.trim(),
+                        password: personalDetails.password,
+                },
+                companyDetails: {
+                        ...mappedCompany,
+                        companyName: companyDetails.companyName.trim(),
+                        companyEmail: companyDetails.companyEmail.trim().toLowerCase(),
+                        phone: companyDetails.phone.trim(),
+                        brandName: (companyDetails.brandName || "").trim(),
+                        brandDescription: (companyDetails.brandDescription || "").trim(),
+                        gstinNumber: (companyDetails.gstinNumber || "").trim().toUpperCase(),
+                        companyLogo: (companyDetails.companyLogo || "").trim(),
+                },
+                bankDetails: {
+                        accountHolderName: bankDetails.accountHolderName.trim(),
+                        accountNumber: bankDetails.accountNumber.trim(),
+                        ifscCode: bankDetails.ifscCode.trim().toUpperCase(),
+                        bankName: bankDetails.bankName.trim(),
+                        branchName: bankDetails.branchName.trim(),
+                },
+        };
+};
+
+export const emptyCompanyAddress = () => ({
+        tagName: "Head Office",
+        building: "",
+        street: "",
+        city: "",
+        state: "",
+        pincode: "",
+        country: "India",
+});
+
+export const normalizeCompanyAddressInput = (address) => {
+        if (!address) return [];
+        if (Array.isArray(address)) {
+                return address
+                        .map((entry) => normalizeCompanyAddressInput(entry)[0])
+                        .filter(Boolean);
+        }
+        const values = Object.values(address).map((value) => `${value ?? ""}`.trim());
+        const hasValues = values.some((value) => value);
+        if (!hasValues) return [];
+        const parsed = addressSchema.safeParse({
+                ...address,
+                tagName: address.tagName?.trim() || "Head Office",
+                building: address.building?.trim() || "",
+                street: address.street?.trim() || "",
+                city: address.city?.trim() || "",
+                state: address.state?.trim() || "",
+                pincode: address.pincode?.trim() || "",
+                country: address.country?.trim() || "India",
+        });
+        return parsed.success ? [parsed.data] : [];
+};


### PR DESCRIPTION
## Summary
- add reusable seller registration zod schemas that cover personal, company, and bank information along with helpers
- create a SellerBankDetails model and update the seller registration API to store validated company and bank data while handling duplicates
- rebuild the seller registration page into a multi-step experience wired to the new schema and update the auth store to report loading state correctly
