### PR TITLE
Stop persisting shipment logs to file

### DIFF
--- a/lib/reports/shipmentLogger.js
+++ b/lib/reports/shipmentLogger.js
@@ -1,13 +1,7 @@
-import fs from "fs";
-import path from "path";
-
-const LOG_DIR = path.join(process.cwd(), "logs");
-const SHIPMENT_LOG_FILE = path.join(LOG_DIR, "shipment-logs.json");
-
-// Ensure logs directory exists
-if (!fs.existsSync(LOG_DIR)) {
-	fs.mkdirSync(LOG_DIR, { recursive: true });
-}
+// Maintain shipment logs in-memory rather than writing to disk. This prevents
+// the application from creating or updating the `logs/shipment-logs.json` file
+// while still giving us access to recent log history for debugging purposes.
+const shipmentLogs = [];
 
 /**
  * Log shipment events for tracking and debugging
@@ -23,29 +17,12 @@ export function logShipmentEvent(logData) {
 	// Console log for immediate visibility
 	console.log(`📝 SHIPMENT LOG [${logData.action?.toUpperCase()}]:`, logEntry);
 
-	// Write to file for persistent logging
-	try {
-		let logs = [];
+        // Persist in memory only. Keep the list to a manageable size.
+        shipmentLogs.push(logEntry);
 
-		// Read existing logs
-		if (fs.existsSync(SHIPMENT_LOG_FILE)) {
-			const fileContent = fs.readFileSync(SHIPMENT_LOG_FILE, "utf8");
-			logs = JSON.parse(fileContent);
-		}
-
-		// Add new log entry
-		logs.push(logEntry);
-
-		// Keep only last 1000 entries to prevent file from growing too large
-		if (logs.length > 1000) {
-			logs = logs.slice(-1000);
-		}
-
-		// Write back to file
-		fs.writeFileSync(SHIPMENT_LOG_FILE, JSON.stringify(logs, null, 2));
-	} catch (error) {
-		console.error("Failed to write shipment log:", error);
-	}
+        if (shipmentLogs.length > 1000) {
+                shipmentLogs.splice(0, shipmentLogs.length - 1000);
+        }
 
 	return logEntry;
 }
@@ -56,19 +33,7 @@ export function logShipmentEvent(logData) {
  * @returns {Array} Array of log entries
  */
 export function getShipmentLogs(subOrderId) {
-	try {
-		if (!fs.existsSync(SHIPMENT_LOG_FILE)) {
-			return [];
-		}
-
-		const fileContent = fs.readFileSync(SHIPMENT_LOG_FILE, "utf8");
-		const logs = JSON.parse(fileContent);
-
-		return logs.filter((log) => log.subOrderId === subOrderId);
-	} catch (error) {
-		console.error("Failed to read shipment logs:", error);
-		return [];
-	}
+        return shipmentLogs.filter((log) => log.subOrderId === subOrderId);
 }
 
 /**
@@ -77,37 +42,27 @@ export function getShipmentLogs(subOrderId) {
  * @returns {Array} Array of log entries
  */
 export function getAllShipmentLogs(filters = {}) {
-	try {
-		if (!fs.existsSync(SHIPMENT_LOG_FILE)) {
-			return [];
-		}
+        let logs = [...shipmentLogs];
 
-		const fileContent = fs.readFileSync(SHIPMENT_LOG_FILE, "utf8");
-		let logs = JSON.parse(fileContent);
+        // Apply filters
+        if (filters.action) {
+                logs = logs.filter((log) => log.action === filters.action);
+        }
+        if (filters.status) {
+                logs = logs.filter((log) => log.status === filters.status);
+        }
+        if (filters.dateFrom) {
+                logs = logs.filter(
+                        (log) => new Date(log.timestamp) >= new Date(filters.dateFrom)
+                );
+        }
+        if (filters.dateTo) {
+                logs = logs.filter(
+                        (log) => new Date(log.timestamp) <= new Date(filters.dateTo)
+                );
+        }
 
-		// Apply filters
-		if (filters.action) {
-			logs = logs.filter((log) => log.action === filters.action);
-		}
-		if (filters.status) {
-			logs = logs.filter((log) => log.status === filters.status);
-		}
-		if (filters.dateFrom) {
-			logs = logs.filter(
-				(log) => new Date(log.timestamp) >= new Date(filters.dateFrom)
-			);
-		}
-		if (filters.dateTo) {
-			logs = logs.filter(
-				(log) => new Date(log.timestamp) <= new Date(filters.dateTo)
-			);
-		}
-
-		return logs;
-	} catch (error) {
-		console.error("Failed to read shipment logs:", error);
-		return [];
-	}
+        return logs;
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace the shipment logging persistence layer with an in-memory store to avoid writing to `logs/shipment-logs.json`
- retain existing filtering utilities while keeping only the most recent entries in memory
