### PR TITLE
Fix seller API handler block closure

### DIFF
--- a/app/api/admin/sellers/route.js
+++ b/app/api/admin/sellers/route.js
@@ -160,7 +160,6 @@ export async function POST(request) {
 
                         seller.company = company._id;
                         await seller.save();
-                        }
                 }
 
                 // Remove password from response


### PR DESCRIPTION
## Summary
- remove the extra closing brace in the seller creation handler to restore valid syntax
