### PR TITLE
Fix promotion banner uploads to persist Cloudinary metadata

### DIFF
--- a/app/api/admin/brand-promotions/route.js
+++ b/app/api/admin/brand-promotions/route.js
@@ -35,6 +35,7 @@ function serializeBanner(banner) {
                 discountPercentage: banner.discountPercentage ?? 0,
                 tagline: banner.tagline || "",
                 bannerImage: banner.bannerImage,
+                bannerImagePublicId: banner.bannerImagePublicId || "",
                 isActive: banner.isActive,
                 displayOrder: banner.displayOrder ?? 0,
                 createdAt: banner.createdAt,
@@ -77,7 +78,15 @@ export async function POST(request) {
         }
 
         try {
-                const { brandName, discountPercentage, tagline, bannerImage, isActive = true, displayOrder = 0 } =
+                const {
+                        brandName,
+                        discountPercentage,
+                        tagline,
+                        bannerImage,
+                        bannerImagePublicId,
+                        isActive = true,
+                        displayOrder = 0,
+                } =
                         await request.json();
 
                 if (!brandName || !brandName.trim()) {
@@ -90,6 +99,13 @@ export async function POST(request) {
                 if (!bannerImage || !bannerImage.trim()) {
                         return NextResponse.json(
                                 { success: false, message: "Banner image is required" },
+                                { status: 400 }
+                        );
+                }
+
+                if (!bannerImagePublicId || !bannerImagePublicId.trim()) {
+                        return NextResponse.json(
+                                { success: false, message: "Banner image public id is required" },
                                 { status: 400 }
                         );
                 }
@@ -107,6 +123,7 @@ export async function POST(request) {
                         discountPercentage: discountValue,
                         tagline: tagline?.trim() || "",
                         bannerImage: bannerImage.trim(),
+                        bannerImagePublicId: bannerImagePublicId.trim(),
                         isActive: Boolean(isActive),
                         displayOrder: Number.isFinite(Number(displayOrder)) ? Number(displayOrder) : 0,
                 });

--- a/app/api/home/route.js
+++ b/app/api/home/route.js
@@ -113,6 +113,7 @@ export async function GET(request) {
                         discountPercentage: banner.discountPercentage ?? 0,
                         tagline: banner.tagline || "",
                         bannerImage: banner.bannerImage,
+                        bannerImagePublicId: banner.bannerImagePublicId || "",
                         displayOrder: banner.displayOrder ?? 0,
                 });
 

--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import cloudinary from "@/lib/cloudinary.js";
-import { Readable } from "stream";
 
 const ALLOWED_FOLDERS = {
         safety_user_pic: "safety_user_pic",
@@ -46,56 +45,50 @@ export async function POST(req) {
 			);
 		}
 
-		const arrayBuffer = await file.arrayBuffer();
-		const buffer = Buffer.from(arrayBuffer);
+                const arrayBuffer = await file.arrayBuffer();
+                const buffer = Buffer.from(arrayBuffer);
+                const base64 = buffer.toString("base64");
+                const dataUri = `data:${file.type};base64,${base64}`;
 
-		const url = await new Promise((resolve, reject) => {
-			const upload = cloudinary.uploader.upload_stream(
-				{
-					resource_type: "image",
-					folder: folderName,
-					transformation: [{ width: 1600, height: 1600, crop: "limit" }],
-					quality: "auto",
-					format: "webp",
-					use_filename: true,
-					unique_filename: true,
-				},
-				(error, result) => {
-					if (error) return reject(error);
-					resolve(result.secure_url);
-				}
-			);
+                const result = await cloudinary.uploader.upload(dataUri, {
+                        resource_type: "image",
+                        folder: folderName,
+                        transformation: [{ width: 1600, height: 1600, crop: "limit" }],
+                        quality: "auto",
+                        format: "webp",
+                        use_filename: true,
+                        unique_filename: true,
+                });
 
-			// Create readable stream from buffer
-			const readable = new Readable();
-			readable._read = () => {};
-			readable.push(buffer);
-			readable.push(null);
-			readable.pipe(upload);
-		});
-
-		return NextResponse.json(
-			{
-				success: true,
-				url,
-				message: "Upload successful",
-			},
-			{ status: 200 }
-		);
+                return NextResponse.json(
+                        {
+                                success: true,
+                                url: result.secure_url,
+                                publicId: result.public_id,
+                                assetId: result.asset_id,
+                                message: "Upload successful",
+                        },
+                        { status: 200 }
+                );
 	} catch (error) {
 		console.error("[upload] error:", error);
 
 		// Return more specific error messages
-		let errorMessage = "Upload failed";
-		if (error.message?.includes("Invalid image file")) {
-			errorMessage = "Invalid image file";
-		} else if (error.message?.includes("File too large")) {
-			errorMessage = "File too large";
-		}
+                let errorMessage = "Upload failed";
+                const cloudinaryMessage = error?.response?.body?.error?.message;
+                if (cloudinaryMessage) {
+                        errorMessage = cloudinaryMessage;
+                } else if (error.message?.includes("Invalid image file")) {
+                        errorMessage = "Invalid image file";
+                } else if (error.message?.includes("File too large")) {
+                        errorMessage = "File too large";
+                } else if (error.message) {
+                        errorMessage = error.message;
+                }
 
-		return NextResponse.json(
-			{ success: false, message: errorMessage },
-			{ status: 500 }
+                return NextResponse.json(
+                        { success: false, message: errorMessage },
+                        { status: 500 }
 		);
 	}
 }

--- a/model/BrandPromotion.js
+++ b/model/BrandPromotion.js
@@ -23,6 +23,11 @@ const BrandPromotionSchema = new mongoose.Schema(
                         required: true,
                         trim: true,
                 },
+                bannerImagePublicId: {
+                        type: String,
+                        trim: true,
+                        default: "",
+                },
                 isActive: {
                         type: Boolean,
                         default: true,


### PR DESCRIPTION
## Summary
- update the upload handler to stream images to Cloudinary via base64, return metadata, and improve error messaging
- persist Cloudinary public IDs for brand promotions across creation, updates, deletes, and surface them through the admin and home APIs
- adjust the admin promotion banner form to manage Cloudinary metadata when uploading, editing, or reusing banner images
