### PR TITLE
Fix Cloudinary config check import

### DIFF
--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import cloudinary from "@/lib/cloudinary.js";
+import cloudinary, {
+        isCloudinaryConfigured,
+        missingCloudinaryConfig,
+} from "@/lib/cloudinary.js";
 
 const ALLOWED_FOLDERS = {
         safety_user_pic: "safety_user_pic",


### PR DESCRIPTION
## Summary
- import the Cloudinary configuration helpers in the upload API route so configuration checks work at runtime
