### PR TITLE
Remove billing address support

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -68,15 +68,14 @@ export default function CheckoutPage() {
 		selectedAddressId,
 		newAddress,
 		isAddingNewAddress,
-		orderSummary,
-		appliedCoupon,
-		cartAppliedCoupon,
-		currentStep,
-		isLoading,
-		paymentLoading,
-		paymentMethod,
-		hasBillToAddress,
-	} = useCheckoutStore();
+                orderSummary,
+                appliedCoupon,
+                cartAppliedCoupon,
+                currentStep,
+                isLoading,
+                paymentLoading,
+                paymentMethod,
+        } = useCheckoutStore();
 
 	// Checkout store actions
 	const setCheckoutType = useCheckoutStore((state) => state.setCheckoutType);
@@ -95,10 +94,7 @@ export default function CheckoutPage() {
 	const toggleAddNewAddress = useCheckoutStore(
 		(state) => state.toggleAddNewAddress
 	);
-	const copyShippingToBillTo = useCheckoutStore(
-		(state) => state.copyShippingToBillTo
-	);
-	const applyCoupon = useCheckoutStore((state) => state.applyCoupon);
+        const applyCoupon = useCheckoutStore((state) => state.applyCoupon);
 	const removeCoupon = useCheckoutStore((state) => state.removeCoupon);
 	const processPayment = useCheckoutStore((state) => state.processPayment);
 	const getSelectedAddress = useCheckoutStore(
@@ -349,31 +345,13 @@ export default function CheckoutPage() {
 					</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					{!hasBillToAddress && (
-						<div className="p-3 bg-yellow-50 border border-yellow-200 rounded-md text-sm text-yellow-800">
-							No billing address found. Please add one to continue.
-							{selectedAddressId && (
-								<Button
-									size="sm"
-									className="mt-2"
-									onClick={copyShippingToBillTo}
-									disabled={isLoading}
-								>
-									Use selected shipping address
-								</Button>
-							)}
-						</div>
-					)}
-
-					{/* Saved Addresses */}
-					{savedAddresses.length > 0 && (
-						<div className="space-y-3">
-							<h4 className="font-medium">Saved Addresses</h4>
-							{savedAddresses
-								.filter((address) => address.addressType !== "billTo")
-								.map((address) => (
-									<div
-										key={address._id}
+                                        {/* Saved Addresses */}
+                                        {savedAddresses.length > 0 && (
+                                                <div className="space-y-3">
+                                                        <h4 className="font-medium">Saved Addresses</h4>
+                                                        {savedAddresses.map((address) => (
+                                                                        <div
+                                                                                key={address._id}
 										className={`p-4 border rounded-lg cursor-pointer transition-colors ${
 											selectedAddressId === address._id
 												? "border-blue-500 bg-blue-50"
@@ -475,23 +453,6 @@ export default function CheckoutPage() {
 											<SelectItem value="home">Home</SelectItem>
 											<SelectItem value="office">Office</SelectItem>
 											<SelectItem value="other">Other</SelectItem>
-										</SelectContent>
-									</Select>
-								</div>
-								<div>
-									<Label htmlFor="addressType">Address Type</Label>
-									<Select
-										value={newAddress.addressType}
-										onValueChange={(value) =>
-											handleNewAddressChange("addressType", value)
-										}
-									>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="shipTo">Ship To</SelectItem>
-											<SelectItem value="billTo">Bill To</SelectItem>
 										</SelectContent>
 									</Select>
 								</div>
@@ -598,11 +559,11 @@ export default function CheckoutPage() {
 					)}
 
 					{/* Continue Button */}
-					<Button
-						onClick={() => setCurrentStep(2)}
-						disabled={!selectedAddressId || !hasBillToAddress}
-						className="w-full"
-					>
+                                        <Button
+                                                onClick={() => setCurrentStep(2)}
+                                                disabled={!selectedAddressId}
+                                                className="w-full"
+                                        >
 						Continue to Payment
 						<ArrowRight className="ml-2 h-4 w-4" />
 					</Button>
@@ -613,12 +574,10 @@ export default function CheckoutPage() {
 			savedAddresses,
 			selectedAddressId,
 			isAddingNewAddress,
-			newAddress,
-			isLoading,
-			hasBillToAddress,
-			copyShippingToBillTo,
-			handleAddressSelect,
-			handleNewAddressChange,
+                        newAddress,
+                        isLoading,
+                        handleAddressSelect,
+                        handleNewAddressChange,
 			handleAddNewAddress,
 			toggleAddNewAddress,
 			setCurrentStep,

--- a/app/api/user/addresses/route.js
+++ b/app/api/user/addresses/route.js
@@ -84,14 +84,13 @@ export async function POST(request) {
 			);
 		}
 
-		const {
-			tag,
-			addressType,
-			name,
-			street,
-			city,
-			state,
-			zipCode,
+                const {
+                        tag,
+                        name,
+                        street,
+                        city,
+                        state,
+                        zipCode,
 			country = "India",
 			isDefault = false,
 		} = addressData;
@@ -119,13 +118,12 @@ export async function POST(request) {
 		}
 
 		// Add new address
-		const newAddress = {
-			tag,
-			addressType,
-			name,
-			street,
-			city,
-			state,
+                const newAddress = {
+                        tag,
+                        name,
+                        street,
+                        city,
+                        state,
 			zipCode,
 			country,
 			isDefault,

--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -460,9 +460,9 @@ export function MyProfile() {
 					<CardHeader className="flex flex-row items-center justify-between">
 						<div>
 							<CardTitle>Addresses</CardTitle>
-							<CardDescription>
-								Manage your shipping and billing addresses
-							</CardDescription>
+                                                        <CardDescription>
+                                                                Manage your saved shipping addresses
+                                                        </CardDescription>
 						</div>
 						<AddressFormDialog
 							trigger={
@@ -489,11 +489,6 @@ export function MyProfile() {
 									<div className="flex items-center justify-between mb-2">
 										<div className="font-medium capitalize">
 											{addr.tag} Address{" "}
-											{addr?.addressType && (
-												<span className="ml-2 text-xs bg-primary text-primary-foreground px-2 py-1 rounded">
-													{addr.addressType}
-												</span>
-											)}
 											{addr.isDefault && (
 												<span className="ml-2 text-xs bg-primary text-primary-foreground px-2 py-1 rounded">
 													Default

--- a/components/BuyerPanel/account/tabs/SubComponents/AddressFormDialog.jsx
+++ b/components/BuyerPanel/account/tabs/SubComponents/AddressFormDialog.jsx
@@ -24,32 +24,30 @@ import { addressSchema } from "@/zodSchema/addressSchema.js";
 
 export default function AddressFormDialog({ trigger, initial, onSave }) {
 	const [open, setOpen] = useState(false);
-	const [form, setForm] = useState({
-		tag: "home",
-		addressType: "shipTo",
-		name: "",
-		street: "",
-		city: "",
-		state: "",
-		zipCode: "",
+        const [form, setForm] = useState({
+                tag: "home",
+                name: "",
+                street: "",
+                city: "",
+                state: "",
+                zipCode: "",
 		country: "India",
 		isDefault: false,
 	});
 	const [errors, setErrors] = useState({});
 
 	useEffect(() => {
-		if (initial) {
-			setForm({ ...form, ...initial });
-		} else {
-			// Reset form when adding new address
-			setForm({
-				tag: "home",
-				addressType: "shipTo",
-				name: "",
-				street: "",
-				city: "",
-				state: "",
-				zipCode: "",
+                if (initial) {
+                        setForm({ ...form, ...initial });
+                } else {
+                        // Reset form when adding new address
+                        setForm({
+                                tag: "home",
+                                name: "",
+                                street: "",
+                                city: "",
+                                state: "",
+                                zipCode: "",
 				country: "India",
 				isDefault: false,
 			});
@@ -79,21 +77,21 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 			return;
 		}
 
-		onSave?.(form);
+                onSave?.(result.data);
 		setOpen(false);
 
 		// Reset form after successful save if it's a new address
-		if (!initial) {
-			setForm({
-				tag: "home",
-				name: "",
-				street: "",
-				city: "",
-				state: "",
-				zipCode: "",
-				country: "India",
-				isDefault: false,
-			});
+                if (!initial) {
+                        setForm({
+                                tag: "home",
+                                name: "",
+                                street: "",
+                                city: "",
+                                state: "",
+                                zipCode: "",
+                                country: "India",
+                                isDefault: false,
+                        });
 		}
 	}
 
@@ -147,26 +145,6 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 								<p className="text-xs text-red-500">{errors.name}</p>
 							)}
 						</div>
-					</div>
-
-					{/* Address Type */}
-					<div className="space-y-2">
-						<Label htmlFor="addressType">Address Type </Label>
-						<Select
-							value={form.addressType}
-							onValueChange={(value) => set("addressType", value)}
-						>
-							<SelectTrigger>
-								<SelectValue placeholder="Select address type" />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="billTo">Bill To</SelectItem>
-								<SelectItem value="shipTo">Ship To</SelectItem>
-							</SelectContent>
-						</Select>
-						{errors.addressType && (
-							<p className="text-xs text-red-500">{errors.addressType}</p>
-						)}
 					</div>
 
 					{/* Street Address */}

--- a/lib/invoicePDF.js
+++ b/lib/invoicePDF.js
@@ -376,7 +376,6 @@
 // 	}));
 
 // 	const products = Array.isArray(order?.products) ? order.products : [];
-// 	const billingAddress = order?.billToAddress || null;
 // 	const shippingAddress = order?.deliveryAddress || null;
 
 // 	return (
@@ -422,31 +421,15 @@
 // 				<View style={styles.infoSection}>
 // 					<View style={styles.infoBlock}>
 // 						<Text style={styles.infoTitle}>Billed To</Text>
-// 						{billingAddress ? (
 // 							<>
-// 								{billingAddress.name && (
-// 									<Text style={styles.infoText}>{billingAddress.name}</Text>
 // 								)}
-// 								{billingAddress.street && (
-// 									<Text style={styles.infoText}>{billingAddress.street}</Text>
 // 								)}
-// 								{(billingAddress.city ||
-// 									billingAddress.state ||
-// 									billingAddress.zipCode) && (
 // 									<Text style={styles.infoText}>
-// 										{billingAddress.city || ""}
-// 										{billingAddress.state ? `, ${billingAddress.state}` : ""}
-// 										{billingAddress.zipCode
-// 											? ` - ${billingAddress.zipCode}`
 // 											: ""}
 // 									</Text>
 // 								)}
-// 								{billingAddress.country && (
-// 									<Text style={styles.infoText}>{billingAddress.country}</Text>
 // 								)}
-// 								{billingAddress.gstin && (
 // 									<Text style={styles.infoText}>
-// 										GSTIN: {billingAddress.gstin}
 // 									</Text>
 // 								)}
 // 							</>
@@ -489,8 +472,6 @@
 // 									<Text style={styles.infoText}>{shippingAddress.country}</Text>
 // 								)}
 // 							</>
-// 						) : billingAddress ? (
-// 							<Text style={styles.infoText}>Same as billing address</Text>
 // 						) : (
 // 							<Text style={styles.infoText}>Shipping address not provided</Text>
 // 						)}
@@ -1048,12 +1029,12 @@ const InvoiceDocument = ({ order }) => {
 	// 	amount: line.amount,
 	// }));
 
-	const products = Array.isArray(order?.products) ? order.products : [];
-	const billingAddress = order?.billToAddress || null;
-	const shippingAddress = order?.deliveryAddress || null;
+        const products = Array.isArray(order?.products) ? order.products : [];
+        const deliveryAddress =
+                order?.deliveryAddress || order?.shipToAddress || null;
 
-	return (
-		<Document>
+        return (
+                <Document>
 			<Page size="A4" style={styles.page}>
 				{/* Header */}
 				<View style={styles.header}>
@@ -1088,38 +1069,46 @@ const InvoiceDocument = ({ order }) => {
 				{/* Customer Information */}
 				<View style={styles.section}>
 					<View style={styles.row}>
-						<View>
-							<Text style={styles.sectionTitle}>Bill To:</Text>
+                                                <View>
+                                                        <Text style={styles.sectionTitle}>Customer:</Text>
 
-							{order.billToAddress ? (
-								<>
-									{order.billToAddress.name && (
-										<Text>{order.billToAddress.name}</Text>
-									)}
-									<Text>{order.billToAddress.street}</Text>
-									<Text>
-										{order.billToAddress.city}, {order.billToAddress.state} -{" "}
-										{order.billToAddress.zipCode}
-									</Text>
-									<Text>{order.billToAddress.country}</Text>
-								</>
-							) : (
-								<>
-									{/* <Text>{order.customerName}</Text>
-									<Text>{order.customerEmail}</Text>
-									<Text>{order.customerMobile}</Text> */}
-									{order.deliveryAddress.name && (
-										<Text>{order.deliveryAddress.name}</Text>
-									)}
-									<Text>{order.deliveryAddress.street}</Text>
-									<Text>
-										{order.deliveryAddress.city}, {order.deliveryAddress.state}{" "}
-										- {order.deliveryAddress.zipCode}
-									</Text>
-									<Text>{order.deliveryAddress.country}</Text>
-								</>
-							)}
-						</View>
+                                                        {deliveryAddress ? (
+                                                                <>
+                                                                        {deliveryAddress.name && (
+                                                                                <Text>{deliveryAddress.name}</Text>
+                                                                        )}
+                                                                        {deliveryAddress.street && (
+                                                                                <Text>{deliveryAddress.street}</Text>
+                                                                        )}
+                                                                        {(deliveryAddress.city || deliveryAddress.state) && (
+                                                                                <Text>
+                                                                                        {deliveryAddress.city}
+                                                                                        {deliveryAddress.state
+                                                                                                ? `, ${deliveryAddress.state}`
+                                                                                                : ""}
+                                                                                        {deliveryAddress.zipCode
+                                                                                                ? ` - ${deliveryAddress.zipCode}`
+                                                                                                : ""}
+                                                                                </Text>
+                                                                        )}
+                                                                        {deliveryAddress.country && (
+                                                                                <Text>{deliveryAddress.country}</Text>
+                                                                        )}
+                                                                </>
+                                                        ) : (
+                                                                <>
+                                                                        {order.customerName && (
+                                                                                <Text>{order.customerName}</Text>
+                                                                        )}
+                                                                        {order.customerEmail && (
+                                                                                <Text>{order.customerEmail}</Text>
+                                                                        )}
+                                                                        {order.customerMobile && (
+                                                                                <Text>{order.customerMobile}</Text>
+                                                                        )}
+                                                                </>
+                                                        )}
+                                                </View>
 						{/* Ship To Address */}
 						{order.deliveryAddress && (
 							<View>

--- a/lib/orders/email.js
+++ b/lib/orders/email.js
@@ -132,7 +132,6 @@ export function normalizeOrderForEmail(order) {
                 deliveryAddress:
                         plainOrder.deliveryAddress ||
                         plainOrder.shipToAddress ||
-                        plainOrder.billToAddress ||
                         {},
                 products,
         };

--- a/model/User.js
+++ b/model/User.js
@@ -2,23 +2,17 @@ import mongoose from "mongoose";
 import bcrypt from "bcryptjs";
 
 const AddressSchema = new mongoose.Schema(
-	{
-		tag: {
-			type: String,
-			required: true,
-			enum: ["home", "office", "other"],
-			default: "home",
-		},
-		addressType: {
-			type: String,
-			required: true,
-			enum: ["billTo", "shipTo"],
-			default: "shipTo",
-		},
-		name: { type: String, required: true },
-		street: { type: String, required: true },
-		city: { type: String, required: true },
-		state: { type: String, required: true },
+        {
+                tag: {
+                        type: String,
+                        required: true,
+                        enum: ["home", "office", "other"],
+                        default: "home",
+                },
+                name: { type: String, required: true },
+                street: { type: String, required: true },
+                city: { type: String, required: true },
+                state: { type: String, required: true },
 		zipCode: { type: String, required: true },
 		country: { type: String, default: "India" },
 		isDefault: { type: Boolean, default: false },
@@ -68,18 +62,8 @@ UserSchema.pre("save", async function () {
 	this.password = await bcrypt.hash(this.password, 12);
 });
 
-UserSchema.pre("save", function (next) {
-	const billToCount = this.addresses.filter(
-		(a) => a.addressType === "billTo"
-	).length;
-	if (billToCount > 1) {
-		return next(new Error("A user can only have one billTo address"));
-	}
-	next();
-});
-
 UserSchema.methods.comparePassword = function (password) {
-	return bcrypt.compare(password, this.password);
+        return bcrypt.compare(password, this.password);
 };
 
 export default mongoose.models.User || mongoose.model("User", UserSchema);

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -153,19 +153,17 @@ export const useCheckoutStore = create(
 				// Delivery Address Management
 				savedAddresses: [],
 				selectedAddressId: null,
-				newAddress: {
-					tag: "home",
-					addressType: "shipTo",
-					name: "",
-					street: "",
-					city: "",
-					state: "",
-					zipCode: "",
-					country: "India",
-					isDefault: false,
-				},
-				isAddingNewAddress: false,
-				hasBillToAddress: false,
+                                newAddress: {
+                                        tag: "home",
+                                        name: "",
+                                        street: "",
+                                        city: "",
+                                        state: "",
+                                        zipCode: "",
+                                        country: "India",
+                                        isDefault: false,
+                                },
+                                isAddingNewAddress: false,
 
 				// Order Summary
 				orderSummary: {
@@ -306,29 +304,17 @@ export const useCheckoutStore = create(
 				},
 
 				// Load user addresses
-				loadUserAddresses: async () => {
-					set({ isLoading: true });
-					try {
-						const data = await paymentAPI.getUserAddresses();
-						if (data.success) {
-							const hasBillTo = data.addresses.some(
-								(addr) => addr.addressType === "billTo"
-							);
-							set({
-								savedAddresses: data.addresses,
-								hasBillToAddress: hasBillTo,
-							});
+                                loadUserAddresses: async () => {
+                                        set({ isLoading: true });
+                                        try {
+                                                const data = await paymentAPI.getUserAddresses();
+                                                if (data.success) {
+                                                        set({ savedAddresses: data.addresses });
 
-							if (!hasBillTo) {
-								toast.error(
-									"Please add a billing address to continue checkout"
-								);
-							}
-
-							// Auto-select default address if available
-							const defaultAddress = data.addresses.find(
-								(addr) => addr.isDefault
-							);
+                                                        // Auto-select default address if available
+                                                        const defaultAddress = data.addresses.find(
+                                                                (addr) => addr.isDefault
+                                                        );
 							if (defaultAddress) {
 								set({ selectedAddressId: defaultAddress._id });
 							}
@@ -364,14 +350,13 @@ export const useCheckoutStore = create(
 							await get().loadUserAddresses();
 
 							// Reset new address form
-							set({
-								newAddress: {
-									tag: "home",
-									addressType: "shipTo",
-									name: "",
-									street: "",
-									city: "",
-									state: "",
+                                                        set({
+                                                                newAddress: {
+                                                                        tag: "home",
+                                                                        name: "",
+                                                                        street: "",
+                                                                        city: "",
+                                                                        state: "",
 									zipCode: "",
 									country: "India",
 									isDefault: false,
@@ -504,46 +489,10 @@ export const useCheckoutStore = create(
 					}
 				},
 
-				// Toggle add new address form
-				toggleAddNewAddress: () => {
-					set((state) => ({ isAddingNewAddress: !state.isAddingNewAddress }));
-				},
-
-				// Copy selected shipping address as billing address
-				copyShippingToBillTo: async () => {
-					const { selectedAddressId, savedAddresses, loadUserAddresses } =
-						get();
-					if (!selectedAddressId) {
-						toast.error("Select a shipping address first");
-						return;
-					}
-					const shipAddress = savedAddresses.find(
-						(addr) => addr._id === selectedAddressId
-					);
-					if (!shipAddress || shipAddress.addressType !== "shipTo") {
-						toast.error("Selected address must be a shipping address");
-						return;
-					}
-
-					set({ isLoading: true });
-					try {
-						const { _id, addressType, ...addressData } = shipAddress;
-						const data = await paymentAPI.addUserAddress({
-							...addressData,
-							addressType: "billTo",
-							isDefault: false,
-						});
-						if (data.success) {
-							await loadUserAddresses();
-							toast.success("Billing address copied from shipping address");
-						}
-					} catch (error) {
-						console.error("Failed to copy address:", error);
-						toast.error(error.message || "Failed to copy address");
-					} finally {
-						set({ isLoading: false });
-					}
-				},
+                                // Toggle add new address form
+                                toggleAddNewAddress: () => {
+                                        set((state) => ({ isAddingNewAddress: !state.isAddingNewAddress }));
+                                },
 
 				// Apply coupon (only for buyNow flow)
 				applyCoupon: async (couponCode) => {

--- a/zodSchema/addressSchema.js
+++ b/zodSchema/addressSchema.js
@@ -1,12 +1,11 @@
 import { z } from "zod";
 
 export const addressSchema = z.object({
-	tag: z.enum(["home", "office", "other"]).default("home"),
-	addressType: z.enum(["billTo", "shipTo"]).default("shipTo"),
-	name: z.string().min(1, "Name is required"),
-	street: z.string().min(1, "Street address is required"),
-	city: z.string().min(1, "City is required"),
-	state: z.string().min(1, "State is required"),
+        tag: z.enum(["home", "office", "other"]).default("home"),
+        name: z.string().min(1, "Name is required"),
+        street: z.string().min(1, "Street address is required"),
+        city: z.string().min(1, "City is required"),
+        state: z.string().min(1, "State is required"),
 	zipCode: z
 		.string()
 		.min(5, "ZIP code must be 5-6 digits")


### PR DESCRIPTION
## Summary
- remove the billing address type from address validation, persistence, and API handling so every saved address is treated as a ship-to location
- simplify checkout and profile address management UIs to list and capture only shipping details
- update order communications to reference the delivery address instead of a billing address
