### PR TITLE
Fix buyer profile address persistence

### DIFF
--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -99,18 +99,22 @@ export function MyProfile() {
 		setPasswordForm((s) => ({ ...s, [k]: v }));
 	}
 
-	async function loadAddresses() {
-		if (!isAuthed || !user?._id) return;
-		try {
-			const res = await fetch(`/api/profile/addresses?userId=${user._id}`);
-			if (res.ok) {
-				const data = await res.json();
-				setAddresses(data.addresses || []);
-			}
-		} catch (error) {
-			console.error("Failed to load addresses:", error);
-		}
-	}
+        async function loadAddresses() {
+                if (!isAuthed || !user?._id) return;
+                try {
+                        const res = await fetch(`/api/profile/addresses?userId=${user._id}`);
+                        if (res.ok) {
+                                const data = await res.json();
+                                const sanitizedAddresses = (data.addresses || []).map((addr) => ({
+                                        ...addr,
+                                        _id: addr?._id?.toString ? addr._id.toString() : addr._id,
+                                }));
+                                setAddresses(sanitizedAddresses);
+                        }
+                } catch (error) {
+                        console.error("Failed to load addresses:", error);
+                }
+        }
 
 	async function saveProfile() {
 		if (!isAuthed || !user?._id) return;
@@ -187,57 +191,118 @@ export function MyProfile() {
 		}
 	}
 
-	async function saveAddresses() {
-		if (!isAuthed || !user?._id) return;
-		setLoading((prev) => ({ ...prev, addresses: true }));
+        async function addAddress(address) {
+                if (!isAuthed || !user?._id) return false;
 
-		try {
-			const res = await fetch("/api/profile/addresses", {
-				method: "PUT",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					userId: user._id,
-					addresses,
-				}),
-			});
+                setLoading((prev) => ({ ...prev, addresses: true }));
 
-			if (res.ok) {
-				toast.success("Addresses updated successfully!");
-			} else {
-				const error = await res.json();
-				toast.error(error.message || "Failed to update addresses");
-			}
-		} catch (error) {
-			console.error("Failed to update addresses:", error);
-			toast.error("Failed to update addresses");
-		} finally {
-			setLoading((prev) => ({ ...prev, addresses: false }));
-		}
-	}
+                try {
+                        const res = await fetch("/api/profile/addresses", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({
+                                        userId: user._id,
+                                        address,
+                                }),
+                        });
 
-	async function deleteAddress(addressId) {
-		if (!isAuthed || !user?._id) return;
+                        const data = await res.json();
 
-		try {
-			const res = await fetch(
-				`/api/profile/addresses?userId=${user._id}&addressId=${addressId}`,
-				{
-					method: "DELETE",
-				}
-			);
+                        if (res.ok) {
+                                toast.success("Address added successfully!");
+                                await loadAddresses();
+                                return true;
+                        }
 
-			if (res.ok) {
-				setAddresses((prev) => prev.filter((addr) => addr._id !== addressId));
-				toast.success("Address deleted successfully!");
-			} else {
-				const error = await res.json();
-				toast.error(error.message || "Failed to delete address");
-			}
-		} catch (error) {
-			console.error("Failed to delete address:", error);
-			toast.error("Failed to delete address");
-		}
-	}
+                        toast.error(data.message || data.error || "Failed to add address");
+                        return false;
+                } catch (error) {
+                        console.error("Failed to add address:", error);
+                        toast.error("Failed to add address");
+                        return false;
+                } finally {
+                        setLoading((prev) => ({ ...prev, addresses: false }));
+                }
+        }
+
+        async function updateAddress(addressId, updatedAddress) {
+                if (!isAuthed || !user?._id) return false;
+
+                setLoading((prev) => ({ ...prev, addresses: true }));
+
+                try {
+                        const updatedList = addresses.map((addr) => {
+                                if ((addr._id || "").toString() === addressId.toString()) {
+                                        return { ...addr, ...updatedAddress };
+                                }
+
+                                if (updatedAddress.isDefault) {
+                                        return { ...addr, isDefault: false };
+                                }
+
+                                return addr;
+                        });
+
+                        const res = await fetch("/api/profile/addresses", {
+                                method: "PUT",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({
+                                        userId: user._id,
+                                        addresses: updatedList,
+                                }),
+                        });
+
+                        const data = await res.json();
+
+                        if (res.ok) {
+                                const sanitizedAddresses = (data.addresses || updatedList).map((addr) => ({
+                                        ...addr,
+                                        _id: addr?._id?.toString ? addr._id.toString() : addr._id,
+                                }));
+                                setAddresses(sanitizedAddresses);
+                                toast.success("Address updated successfully!");
+                                return true;
+                        }
+
+                        toast.error(data.message || data.error || "Failed to update address");
+                        return false;
+                } catch (error) {
+                        console.error("Failed to update address:", error);
+                        toast.error("Failed to update address");
+                        return false;
+                } finally {
+                        setLoading((prev) => ({ ...prev, addresses: false }));
+                }
+        }
+
+        async function deleteAddress(addressId) {
+                if (!isAuthed || !user?._id) return;
+
+                setLoading((prev) => ({ ...prev, addresses: true }));
+
+                try {
+                        const res = await fetch(
+                                `/api/profile/addresses?userId=${user._id}&addressId=${addressId}`,
+                                {
+                                        method: "DELETE",
+                                }
+                        );
+
+                        const data = res.ok ? null : await res.json();
+
+                        if (res.ok) {
+                                toast.success("Address deleted successfully!");
+                                await loadAddresses();
+                        } else {
+                                toast.error(data?.message || data?.error || "Failed to delete address");
+                        }
+                } catch (error) {
+                        console.error("Failed to delete address:", error);
+                        toast.error("Failed to delete address");
+                } finally {
+                        setLoading((prev) => ({ ...prev, addresses: false }));
+                }
+        }
 
 	if (!isAuthed) {
 		return (
@@ -464,18 +529,15 @@ export function MyProfile() {
                                                                 Manage your saved shipping addresses
                                                         </CardDescription>
 						</div>
-						<AddressFormDialog
-							trigger={
-								<Button size="sm">
-									<Plus className="h-4 w-4 mr-2" />
-									Add Address
-								</Button>
-							}
-							onSave={(addr) => {
-								const newAddress = { ...addr, _id: crypto.randomUUID() };
-								setAddresses((a) => [...a, newAddress]);
-							}}
-						/>
+                                                <AddressFormDialog
+                                                        trigger={
+                                                                <Button size="sm" disabled={loading.addresses}>
+                                                                        <Plus className="h-4 w-4 mr-2" />
+                                                                        {loading.addresses ? "Processing..." : "Add Address"}
+                                                                </Button>
+                                                        }
+                                                        onSave={addAddress}
+                                                />
 					</CardHeader>
 					<CardContent>
 						<div className="space-y-4">
@@ -496,28 +558,40 @@ export function MyProfile() {
 											)}
 										</div>
 										<div className="flex gap-2">
-											<AddressFormDialog
-												initial={addr}
-												trigger={
-													<Button variant="ghost" size="sm">
-														<Edit className="h-4 w-4" />
-													</Button>
-												}
-												onSave={(updated) =>
-													setAddresses((list) =>
-														list.map((a) =>
-															a._id === addr._id ? { ...a, ...updated } : a
-														)
-													)
-												}
-											/>
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => deleteAddress(addr._id)}
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
+                                                                                          <AddressFormDialog
+                                                                                                  initial={addr}
+                                                                                                  trigger={
+                                                                                                          <Button
+                                                                                                                  variant="ghost"
+                                                                                                                  size="sm"
+                                                                                                                  disabled={loading.addresses}
+                                                                                                          >
+                                                                                                                  <Edit className="h-4 w-4" />
+                                                                                                          </Button>
+                                                                                                  }
+                                                                                                  onSave={(updated) =>
+                                                                                                          updateAddress(
+                                                                                                                  addr._id?.toString
+                                                                                                                          ? addr._id.toString()
+                                                                                                                          : addr._id,
+                                                                                                                  updated
+                                                                                                          )
+                                                                                                  }
+                                                                                          />
+                                                                                          <Button
+                                                                                                  variant="ghost"
+                                                                                                  size="sm"
+                                                                                                  disabled={loading.addresses}
+                                                                                                  onClick={() =>
+                                                                                                          deleteAddress(
+                                                                                                                  addr._id?.toString
+                                                                                                                          ? addr._id.toString()
+                                                                                                                          : addr._id
+                                                                                                          )
+                                                                                                  }
+                                                                                          >
+                                                                                                  <Trash2 className="h-4 w-4" />
+                                                                                          </Button>
 										</div>
 									</div>
 									<div className="text-sm text-muted-foreground">
@@ -532,13 +606,6 @@ export function MyProfile() {
 								</div>
 							))}
 						</div>
-						{addresses.length > 0 && (
-							<div className="mt-4 flex justify-end">
-								<Button onClick={saveAddresses} disabled={loading.addresses}>
-									{loading.addresses ? "Saving..." : "Save Addresses"}
-								</Button>
-							</div>
-						)}
 					</CardContent>
 				</Card>
 			</motion.div>

--- a/components/BuyerPanel/account/tabs/SubComponents/AddressFormDialog.jsx
+++ b/components/BuyerPanel/account/tabs/SubComponents/AddressFormDialog.jsx
@@ -22,39 +22,32 @@ import {
 } from "@/components/ui/select";
 import { addressSchema } from "@/zodSchema/addressSchema.js";
 
-export default function AddressFormDialog({ trigger, initial, onSave }) {
-	const [open, setOpen] = useState(false);
-        const [form, setForm] = useState({
-                tag: "home",
-                name: "",
-                street: "",
-                city: "",
-                state: "",
-                zipCode: "",
-		country: "India",
-		isDefault: false,
-	});
-	const [errors, setErrors] = useState({});
+const DEFAULT_ADDRESS = {
+        tag: "home",
+        name: "",
+        street: "",
+        city: "",
+        state: "",
+        zipCode: "",
+        country: "India",
+        isDefault: false,
+};
 
-	useEffect(() => {
+export default function AddressFormDialog({ trigger, initial, onSave }) {
+        const [open, setOpen] = useState(false);
+        const [form, setForm] = useState(() => ({ ...DEFAULT_ADDRESS }));
+        const [errors, setErrors] = useState({});
+        const [submitting, setSubmitting] = useState(false);
+
+        useEffect(() => {
                 if (initial) {
-                        setForm({ ...form, ...initial });
+                        setForm({ ...DEFAULT_ADDRESS, ...initial });
                 } else {
-                        // Reset form when adding new address
-                        setForm({
-                                tag: "home",
-                                name: "",
-                                street: "",
-                                city: "",
-                                state: "",
-                                zipCode: "",
-				country: "India",
-				isDefault: false,
-			});
-		}
-		setErrors({});
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [initial, open]);
+                        setForm({ ...DEFAULT_ADDRESS });
+                }
+                setErrors({});
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [initial, open]);
 
 	function set(k, v) {
 		setForm((s) => ({ ...s, [k]: v }));
@@ -64,11 +57,11 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 		}
 	}
 
-	function submit() {
-		const result = addressSchema.safeParse(form);
+        async function submit() {
+                const result = addressSchema.safeParse(form);
 
-		if (!result.success) {
-			// Collect errors in { fieldName: message } format
+                if (!result.success) {
+                        // Collect errors in { fieldName: message } format
 			const fieldErrors = {};
 			result.error.errors.forEach((err) => {
 				fieldErrors[err.path[0]] = err.message;
@@ -77,32 +70,37 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 			return;
 		}
 
-                onSave?.(result.data);
-		setOpen(false);
+                try {
+                        setSubmitting(true);
+                        const resultData = result.data;
+                        const saveResult = await onSave?.(resultData);
 
-		// Reset form after successful save if it's a new address
-                if (!initial) {
-                        setForm({
-                                tag: "home",
-                                name: "",
-                                street: "",
-                                city: "",
-                                state: "",
-                                zipCode: "",
-                                country: "India",
-                                isDefault: false,
-                        });
-		}
-	}
+                        if (saveResult === false) {
+                                return;
+                        }
 
-	function cancel() {
-		setOpen(false);
-		setErrors({});
-		// Reset form to initial state
-		if (initial) {
-			setForm({ ...form, ...initial });
-		}
-	}
+                        setOpen(false);
+
+                        if (!initial) {
+                                setForm({ ...DEFAULT_ADDRESS });
+                        }
+                } catch (error) {
+                        console.error("Failed to submit address form:", error);
+                } finally {
+                        setSubmitting(false);
+                }
+        }
+
+        function cancel() {
+                setOpen(false);
+                setErrors({});
+                // Reset form to initial state
+                if (initial) {
+                        setForm({ ...DEFAULT_ADDRESS, ...initial });
+                } else {
+                        setForm({ ...DEFAULT_ADDRESS });
+                }
+        }
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -221,11 +219,11 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 
 					{/* Default Address Checkbox */}
 					<div className="flex items-center space-x-2">
-						<Checkbox
-							id="isDefault"
-							checked={form.isDefault}
-							onCheckedChange={(checked) => set("isDefault", checked)}
-						/>
+                                                <Checkbox
+                                                        id="isDefault"
+                                                        checked={form.isDefault}
+                                                        onCheckedChange={(checked) => set("isDefault", Boolean(checked))}
+                                                />
 						<Label htmlFor="isDefault" className="text-sm font-normal">
 							Set as default address
 						</Label>
@@ -233,14 +231,18 @@ export default function AddressFormDialog({ trigger, initial, onSave }) {
 
 					<p className="text-xs text-muted-foreground">* Required fields</p>
 				</div>
-				<DialogFooter className="gap-2">
-					<Button variant="outline" onClick={cancel}>
-						Cancel
-					</Button>
-					<Button onClick={submit}>
-						{initial ? "Update Address" : "Add Address"}
-					</Button>
-				</DialogFooter>
+                                <DialogFooter className="gap-2">
+                                        <Button variant="outline" onClick={cancel} disabled={submitting}>
+                                                Cancel
+                                        </Button>
+                                        <Button onClick={submit} disabled={submitting}>
+                                                {submitting
+                                                        ? "Saving..."
+                                                        : initial
+                                                        ? "Update Address"
+                                                        : "Add Address"}
+                                        </Button>
+                                </DialogFooter>
 			</DialogContent>
 		</Dialog>
 	);


### PR DESCRIPTION
## Summary
- integrate the buyer profile address tab with the profile API for creating, updating, and deleting addresses while normalizing returned IDs
- refresh address state after API mutations and guard UI controls with loading states to prevent duplicate submissions
- update the address dialog to support async saves with validation feedback and disabled buttons during submission

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c51733c0832e8ae65e5b080d66a8