### PR TITLE
Enforce GSTIN verification and populate seller addresses

### DIFF
--- a/app/api/admin/sellers/route.js
+++ b/app/api/admin/sellers/route.js
@@ -2,9 +2,10 @@ import { NextResponse } from "next/server";
 import User from "@/model/User.js";
 import Company from "@/model/companyDetails.js";
 import { dbConnect } from "@/lib/dbConnect.js";
+import { fetchGstDetails, extractPrimaryGstAddress } from "@/lib/services/gstVerification.js";
 
 const COMPANY_PROJECTION =
-        "companyName companyEmail phone gstinNumber brandName brandDescription companyLogo";
+        "companyName companyEmail phone gstinNumber brandName brandDescription companyLogo companyAddress";
 
 // GET - Fetch all sellers (exclude admins)
 export async function GET(request) {
@@ -117,20 +118,48 @@ export async function POST(request) {
                                 companyLogo,
                         } = company;
 
-                        if (companyName && companyEmail && phone) {
-                                const company = await Company.create({
-                                        user: seller._id,
-                                        companyName,
-                                        companyEmail,
-                                        phone,
-                                        gstinNumber,
-                                        brandName,
-                                        brandDescription,
-                                        companyLogo,
-                                });
+                        if (!companyName || !companyEmail || !phone || !gstinNumber) {
+                                return NextResponse.json(
+                                        {
+                                                success: false,
+                                                error: "Company name, email, phone, and GSTIN are required",
+                                        },
+                                        { status: 400 }
+                                );
+                        }
 
-                                seller.company = company._id;
-                                await seller.save();
+                        const normalizedGstin = gstinNumber.trim().toUpperCase();
+
+                        let gstPrimaryAddress;
+                        try {
+                                const gstDetails = await fetchGstDetails(normalizedGstin);
+                                gstPrimaryAddress = extractPrimaryGstAddress(gstDetails);
+                        } catch (gstError) {
+                                return NextResponse.json(
+                                        {
+                                                success: false,
+                                                error:
+                                                        gstError.message ||
+                                                        "Failed to fetch GST details for the provided GSTIN",
+                                        },
+                                        { status: 400 }
+                                );
+                        }
+
+                        const company = await Company.create({
+                                user: seller._id,
+                                companyName,
+                                companyEmail,
+                                phone,
+                                gstinNumber: normalizedGstin,
+                                brandName,
+                                brandDescription,
+                                companyLogo,
+                                companyAddress: [gstPrimaryAddress],
+                        });
+
+                        seller.company = company._id;
+                        await seller.save();
                         }
                 }
 

--- a/app/api/seller/company/updateCompany/route.js
+++ b/app/api/seller/company/updateCompany/route.js
@@ -5,6 +5,7 @@ import User from "@/model/User";
 import { dbConnect } from "@/lib/dbConnect";
 import companyDetails from "@/model/companyDetails";
 import { companyUpdateSchema } from "@/zodSchema/companyScema.js";
+import { fetchGstDetails, extractPrimaryGstAddress } from "@/lib/services/gstVerification.js";
 
 export async function PUT(req) {
 	try {
@@ -42,17 +43,78 @@ export async function PUT(req) {
 			return NextResponse.json({ error: first.message }, { status: 400 });
 		}
 
-		const updateData = { ...parsed.data };
-		const updatedCompany = await companyDetails.findByIdAndUpdate(
-			user.company,
-			{ $set: updateData },
-			{ new: true }
-		);
+                const companyDoc = await companyDetails.findById(user.company);
+                if (!companyDoc) {
+                        return NextResponse.json(
+                                { error: "Company not found" },
+                                { status: 404 }
+                        );
+                }
 
-		return NextResponse.json(
-			{ message: "Company updated successfully", company: updatedCompany },
-			{ status: 200 }
-		);
+                const updateData = { ...parsed.data };
+                let gstPrimaryAddress;
+
+                if (typeof updateData.gstinNumber !== "undefined") {
+                        const normalizedGstin = updateData.gstinNumber.trim().toUpperCase();
+
+                        try {
+                                const gstDetails = await fetchGstDetails(normalizedGstin);
+                                gstPrimaryAddress = extractPrimaryGstAddress(gstDetails);
+                        } catch (gstError) {
+                                return NextResponse.json(
+                                        {
+                                                error:
+                                                        gstError.message ||
+                                                        "Failed to verify GST details. Please confirm the GSTIN and try again.",
+                                        },
+                                        { status: 400 }
+                                );
+                        }
+
+                        updateData.gstinNumber = normalizedGstin;
+                }
+
+                Object.entries(updateData).forEach(([key, value]) => {
+                        if (key === "companyAddress" || typeof value === "undefined") {
+                                return;
+                        }
+                        companyDoc[key] = value;
+                });
+
+                const baseAddresses =
+                        typeof updateData.companyAddress !== "undefined"
+                                ? updateData.companyAddress
+                                : companyDoc.companyAddress || [];
+
+                if (gstPrimaryAddress) {
+                        const normalize = (value = "") => `${value}`.trim().toLowerCase();
+                        const remainingAddresses = Array.isArray(baseAddresses)
+                                ? baseAddresses.filter((address, index) => {
+                                          if (!address) return false;
+                                          if (index === 0) return false;
+                                          return !(
+                                                  normalize(address.building) ===
+                                                          normalize(gstPrimaryAddress.building) &&
+                                                  normalize(address.street) === normalize(gstPrimaryAddress.street) &&
+                                                  normalize(address.city) === normalize(gstPrimaryAddress.city) &&
+                                                  normalize(address.state) === normalize(gstPrimaryAddress.state) &&
+                                                  normalize(address.pincode) === normalize(gstPrimaryAddress.pincode) &&
+                                                  normalize(address.country) === normalize(gstPrimaryAddress.country)
+                                          );
+                                  })
+                                : [];
+
+                        companyDoc.companyAddress = [gstPrimaryAddress, ...remainingAddresses];
+                } else if (typeof updateData.companyAddress !== "undefined") {
+                        companyDoc.companyAddress = baseAddresses;
+                }
+
+                await companyDoc.save();
+
+                return NextResponse.json(
+                        { message: "Company updated successfully", company: companyDoc },
+                        { status: 200 }
+                );
 	} catch (error) {
 		console.error("Error updating company:", error);
 		return NextResponse.json(

--- a/components/AdminPanel/Popups/UpdateSellerPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateSellerPopup.jsx
@@ -269,6 +269,7 @@ export function UpdateSellerPopup({ open, onOpenChange, seller }) {
                                                                                         value={formData.gstinNumber}
                                                                                         onChange={handleChange("gstinNumber")}
                                                                                         className="mt-1"
+                                                                                        required
                                                                                 />
                                                                         </div>
                                                                         <div className="md:col-span-2">

--- a/components/SellerPanel/Settings/form.jsx
+++ b/components/SellerPanel/Settings/form.jsx
@@ -178,16 +178,17 @@ export default function ShopForm() {
 									required
 								/>
 							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="gstinNumber">GSTIN (optional)</Label>
-								<Input
-									id="gstinNumber"
-									name="gstinNumber"
-									value={form.gstinNumber}
-									onChange={onChange}
-									placeholder="22AAAAA0000A1Z5"
-								/>
-							</div>
+                                                        <div className="grid gap-2">
+                                                                <Label htmlFor="gstinNumber">GSTIN</Label>
+                                                                <Input
+                                                                        id="gstinNumber"
+                                                                        name="gstinNumber"
+                                                                        value={form.gstinNumber}
+                                                                        onChange={onChange}
+                                                                        placeholder="22AAAAA0000A1Z5"
+                                                                        required
+                                                                />
+                                                        </div>
 						</div>
 
 						<div className="space-y-3">

--- a/lib/services/gstVerification.js
+++ b/lib/services/gstVerification.js
@@ -1,0 +1,209 @@
+import crypto from "crypto";
+
+const GST_SERVICE_PATH = "/services/bv010";
+const CONSENT_TEXT =
+        "I hereby declare my consent for fetching my information via RPACPC API.";
+
+const GST_STATE_CODE_MAP = {
+        "01": "Jammu and Kashmir",
+        "02": "Himachal Pradesh",
+        "03": "Punjab",
+        "04": "Chandigarh",
+        "05": "Uttarakhand",
+        "06": "Haryana",
+        "07": "Delhi",
+        "08": "Rajasthan",
+        "09": "Uttar Pradesh",
+        "10": "Bihar",
+        "11": "Sikkim",
+        "12": "Arunachal Pradesh",
+        "13": "Nagaland",
+        "14": "Manipur",
+        "15": "Mizoram",
+        "16": "Tripura",
+        "17": "Meghalaya",
+        "18": "Assam",
+        "19": "West Bengal",
+        "20": "Jharkhand",
+        "21": "Odisha",
+        "22": "Chhattisgarh",
+        "23": "Madhya Pradesh",
+        "24": "Gujarat",
+        "25": "Daman and Diu",
+        "26": "Dadra and Nagar Haveli",
+        "27": "Maharashtra",
+        "28": "Andhra Pradesh",
+        "29": "Karnataka",
+        "30": "Goa",
+        "31": "Lakshadweep",
+        "32": "Kerala",
+        "33": "Tamil Nadu",
+        "34": "Puducherry",
+        "35": "Andaman and Nicobar Islands",
+        "36": "Telangana",
+        "37": "Andhra Pradesh",
+        "38": "Ladakh",
+        "97": "Other Territory",
+};
+
+const sanitizeStateCode = (value) => {
+        if (!value) return "";
+        const normalized = `${value}`.trim().padStart(2, "0");
+        return GST_STATE_CODE_MAP[normalized] || "";
+};
+
+const readEnvValue = (key) => {
+        const value = process.env[key];
+        if (!value) return "";
+        return `${value}`.trim();
+};
+
+const getGstApiConfig = () => {
+        const baseUrl = readEnvValue("GST_API_BASE_URL");
+        const token = readEnvValue("GST_API_TOKEN");
+        const secret = readEnvValue("GST_API_SECRET");
+
+        if (!baseUrl) {
+                throw new Error("GST API base URL is not configured");
+        }
+
+        if (!token || !secret) {
+                throw new Error("GST API credentials are not configured");
+        }
+
+        return {
+                baseUrl: baseUrl.replace(/\/$/, ""),
+                token,
+                secret,
+        };
+};
+
+export async function fetchGstDetails(gstinNumber) {
+        if (!gstinNumber) {
+                throw new Error("GSTIN is required");
+        }
+
+        const { baseUrl, token, secret } = getGstApiConfig();
+
+        const requestId = crypto.randomUUID();
+        const payload = {
+                request_id: requestId,
+                consent: "Y",
+                consent_text: CONSENT_TEXT,
+                gstNumber: gstinNumber,
+                branchDetails: true,
+                hsnDetails: false,
+                filingDetails: false,
+                filingFrequency: false,
+                liabilityPaidDetails: false,
+        };
+
+        const response = await fetch(`${baseUrl}${GST_SERVICE_PATH}`, {
+                method: "POST",
+                headers: {
+                        "Content-Type": "application/json",
+                        token,
+                        secretkey: secret,
+                },
+                body: JSON.stringify(payload),
+        });
+
+        const parseResponseBody = async () => {
+                try {
+                        return await response.json();
+                } catch {
+                        try {
+                                const text = await response.text();
+                                return text ? { message: text } : null;
+                        } catch {
+                                return null;
+                        }
+                }
+        };
+
+        const data = await parseResponseBody();
+
+        if (!response.ok) {
+                const errorMessage =
+                        data?.message ||
+                        data?.error ||
+                        data?.statusMessage ||
+                        data?.status ||
+                        `GST service returned an unexpected response (${response.status})`;
+                throw new Error(errorMessage);
+        }
+
+        if (!data) {
+                throw new Error("Invalid GST service response");
+        }
+
+        if (data?.success === false) {
+                throw new Error(data?.message || "Failed to fetch GST details");
+        }
+
+        if (data?.status && `${data.status}`.toLowerCase() !== "success") {
+                throw new Error(data?.message || "Failed to fetch GST details");
+        }
+
+        if (data?.error) {
+                throw new Error(data.error);
+        }
+
+        return data;
+}
+
+const getFirstNonEmpty = (payload) => payload.find((entry) => entry && Object.keys(entry).length > 0);
+
+const resolveAddressSource = (payload) => {
+        if (!payload || typeof payload !== "object") return null;
+        const candidates = [
+                payload?.data?.gstDetails?.gstinInfo?.pradr,
+                payload?.data?.gstDetails?.pradr,
+                payload?.data?.gstinInfo?.pradr,
+                payload?.data?.gstinDetails?.pradr,
+                payload?.data?.pradr,
+                payload?.data?.principal_place,
+                payload?.gstinInfo?.pradr,
+                payload?.gstinDetails?.pradr,
+                payload?.result?.pradr,
+                payload?.pradr,
+        ];
+        const selected = getFirstNonEmpty(candidates);
+        if (!selected) return null;
+        if (selected.addr && Object.keys(selected.addr).length > 0) {
+                return selected.addr;
+        }
+        return selected;
+};
+
+export function extractPrimaryGstAddress(payload, { fallbackTag = "Registered Office" } = {}) {
+        const address = resolveAddressSource(payload);
+        if (!address) {
+                throw new Error("GST address details were not found");
+        }
+
+        const buildingParts = [address?.bno, address?.bnm, address?.flno, address?.lg]
+                .map((part) => (part ? `${part}`.trim() : ""))
+                .filter(Boolean);
+        const streetParts = [address?.st, address?.loc]
+                .map((part) => (part ? `${part}`.trim() : ""))
+                .filter(Boolean);
+
+        const city = `${address?.city || address?.dst || ""}`.trim();
+        const stateName = sanitizeStateCode(address?.stcd) || `${address?.state || address?.stateName || ""}`.trim();
+        const pincode = `${address?.pncd || address?.pincode || address?.zip || ""}`.trim();
+
+        if (!city || !stateName || !pincode) {
+                throw new Error("Incomplete GST address details");
+        }
+
+        return {
+                tagName: fallbackTag,
+                building: buildingParts.join(", ") || streetParts.join(", ") || `${city}, ${stateName}`,
+                street: streetParts.join(", ") || buildingParts.join(", ") || `${city}, ${stateName}`,
+                city,
+                state: stateName,
+                pincode,
+                country: "India",
+        };
+}

--- a/zodSchema/companyScema.js
+++ b/zodSchema/companyScema.js
@@ -29,10 +29,10 @@ export const companyBaseSchema = z.object({
                 .optional()
                 .or(z.literal("")),
         gstinNumber: z
-                .string()
+                .string({ required_error: "GSTIN is required" })
+                .trim()
                 .regex(gstinRegex, "Enter a valid GSTIN")
-                .optional()
-                .or(z.literal("")),
+                .transform((value) => value.toUpperCase()),
 	companyLogo: z.string().url("Invalid logo URL").optional().or(z.literal("")),
 });
 


### PR DESCRIPTION
## Summary
- integrate a reusable GST verification service that calls the RPACPC API and extracts the registered address
- require GSTIN for seller onboarding and automatically persist the GST primary address across admin flows and seller self-service APIs
- update validation schemas and UI forms so GSTIN is mandatory when editing company details
- improve GST API error handling so upstream messages are surfaced when onboarding fails
- read GST API credentials at request time and trim values so configured secrets are recognized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f410bd88832e8f6e0827c64ed449